### PR TITLE
Feat: RAITA-52 Parse field data types for OpenSearch

### DIFF
--- a/lambda/adapters/openSearchRepository.ts
+++ b/lambda/adapters/openSearchRepository.ts
@@ -53,14 +53,14 @@ export class OpenSearchRepository implements IMetadataStorageInterface {
   saveFileMetadata = async (data: Array<FileMetadataEntry>) => {
     const client = await this.#getClient();
     // Add entries to the index.
-    const addPromises = data.map(async entry => {
+    const additions = data.map(async entry => {
       const addDocresponse = client.index({
         index: this.#dataIndex,
         body: entry,
       });
       return addDocresponse;
     });
-    await Promise.all(addPromises)
+    await Promise.all(additions)
       .then(data => {
         logger.log(data);
       })

--- a/lambda/mermecParser/fileNameDataParser.ts
+++ b/lambda/mermecParser/fileNameDataParser.ts
@@ -1,5 +1,6 @@
 import { IExtractionSpec, ParseValueResult } from '../types';
 import { logger } from '../utils/logger';
+import { parsePrimitive } from '../utils/parsePrimitives';
 
 export const extractFileNameData = (
   fileName: string,
@@ -20,11 +21,14 @@ export const extractFileNameData = (
   }
   return baseName.split('_').reduce<ParseValueResult>((acc, cur, index) => {
     // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
-    const keyLabel = fileNamePartLabels[suffix][index + 1];
-    if (keyLabel) {
+    const { name, parseAs } = fileNamePartLabels[suffix][index + 1];
+    if (name) {
+      const { key, value } = parseAs
+        ? parsePrimitive(name, cur, parseAs)
+        : { key: name, value: cur };
       // TODO: AWS has replaced spaces in folder names with + character. To decide whether these should be
       // replaced back to spaces.
-      acc[keyLabel] = cur;
+      acc[key] = value;
     }
     return acc;
   }, {});

--- a/lambda/mermecParser/pathDataParser.ts
+++ b/lambda/mermecParser/pathDataParser.ts
@@ -1,27 +1,34 @@
-import { ParseValueResult } from '../types';
+import { IExtractionSpec, ParseValueResult } from '../types';
 import { logger } from '../utils/logger';
+import { parsePrimitive } from '../utils/parsePrimitives';
 
 /**
  * Extract meta data from the file path
  */
 export const extractPathData = (
   path: Array<string>,
-  folderLabels: Record<string, string>,
+  folderLabels: IExtractionSpec['folderTreeExtractionSpec'],
 ) => {
   // Exclude the filename
   const folderNames = path.slice(0, -1);
   // If validation becomes more complex, extract into validation function
+  // TODO: Temporary check for the path parts, update for real setup
   if (folderNames.length < 6 || folderNames.length > 7) {
     logger.log(
       'Unexpected folder path length. Folder path analysis not carried out.',
     );
     return {};
   }
+
+  // TODO: Duplicates now implementation for file name parsing
   return folderNames.reduce<ParseValueResult>((acc, cur, index) => {
     // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
-    const keyLabel = folderLabels[index + 1];
-    if (keyLabel) {
-      acc[keyLabel] = cur;
+    const { name, parseAs } = folderLabels[index + 1];
+    if (name) {
+      const { key, value } = parseAs
+        ? parsePrimitive(name, cur, parseAs)
+        : { key: name, value: cur };
+      acc[key] = value;
     }
     return acc;
   }, {});

--- a/lambda/types/index.ts
+++ b/lambda/types/index.ts
@@ -1,9 +1,9 @@
-export * from "./specification";
-export * from "./portDataStorage";
-export * from "./portFile";
-export * from "./portSpecification";
+export * from './specification';
+export * from './portDataStorage';
+export * from './portFile';
+export * from './portSpecification';
 
-export type ParseValueResult = Record<string, string>;
+export type ParseValueResult = Record<string, string | number>;
 
 export interface FileMetadataEntry {
   fileName: string;

--- a/lambda/types/specification.ts
+++ b/lambda/types/specification.ts
@@ -1,16 +1,26 @@
-import { z } from "zod";
+import { z } from 'zod';
+
+const parseOptions = z.enum(['integer', 'float', 'date']).optional();
 
 export const ColonSeparatedKeyValuePairDefinition = z.object({
   propertyKey: z.string(),
   pattern: z.object({
-    predefinedPatternId: z.literal("colonSeparatedKeyValuePair"),
+    predefinedPatternId: z.literal('colonSeparatedKeyValuePair'),
     searchKey: z.string(),
   }),
+  parseAs: parseOptions,
 });
 
 export type IColonSeparatedKeyValuePairDefinition = z.infer<
   typeof ColonSeparatedKeyValuePairDefinition
 >;
+
+export const FieldExtractionSpecObject = z.object({
+  name: z.string(),
+  parseAs: parseOptions,
+});
+
+// const FieldExtractionSpec = z.union([FieldExtractionSpecObject, z.string()]);
 
 // Note: Update ExtractionSpec to use ExtractionItem when there is more than one
 // const ExtractionItem = z.union([ColonSeparatedKeyValuePairDefinition]);
@@ -20,10 +30,10 @@ export const ExtractionSpec = z.object({
     includeFileNames: z.string().array(),
   }),
   fileNameExtractionSpec: z.object({
-    csv: z.record(z.string()),
-    txt: z.record(z.string()),
+    csv: z.record(z.string(), FieldExtractionSpecObject),
+    txt: z.record(z.string(), FieldExtractionSpecObject),
   }),
-  folderTreeExtractionSpec: z.record(z.string()),
+  folderTreeExtractionSpec: z.record(FieldExtractionSpecObject),
   fileContentExtractionSpec: z.array(ColonSeparatedKeyValuePairDefinition),
 });
 

--- a/lambda/utils/logger.ts
+++ b/lambda/utils/logger.ts
@@ -7,7 +7,7 @@ class Logger {
       (typeof data === 'string' && data) ||
       (data instanceof Error && data.message) ||
       (data instanceof ZodError && data.message) ||
-      JSON.stringify(data);
+      data;
     try {
       console.log(message);
     } catch (error) {

--- a/lambda/utils/parsePrimitives.ts
+++ b/lambda/utils/parsePrimitives.ts
@@ -1,0 +1,18 @@
+import { TargetBaseProps } from 'aws-cdk-lib/aws-events-targets';
+
+export const parsePrimitive = (
+  key: string,
+  data: string,
+  target: 'integer' | 'float' | 'date',
+) => {
+  const parsers: Record<typeof target, (x: string) => number> = {
+    integer: x => parseInt(x),
+    float: x => parseFloat(x),
+    date: x => new Date(x).valueOf(),
+  };
+  try {
+    return { key, value: parsers[target](data) };
+  } catch (error) {
+    return { key: `nonparsed_${key}`, value: data };
+  }
+};

--- a/lambda/utils/parsePrimitives.ts
+++ b/lambda/utils/parsePrimitives.ts
@@ -1,14 +1,14 @@
-import { TargetBaseProps } from 'aws-cdk-lib/aws-events-targets';
+import parse from 'date-fns/parse';
 
 export const parsePrimitive = (
   key: string,
   data: string,
   target: 'integer' | 'float' | 'date',
 ) => {
-  const parsers: Record<typeof target, (x: string) => number> = {
+  const parsers: Record<typeof target, (x: string) => number | string> = {
     integer: x => parseInt(x),
     float: x => parseFloat(x),
-    date: x => new Date(x).valueOf(),
+    date: x => parse(x, 'M/d/y h:m:s a', new Date()).toISOString(),
   };
   try {
     return { key, value: parsers[target](data) };

--- a/lambda/utils/regex.ts
+++ b/lambda/utils/regex.ts
@@ -1,6 +1,7 @@
 const untilEndOfLineCaptureGroup = `([\\p{L}\\p{N}\\p{P} \\t]*)`;
 
+// TODO: Fix parsing os special case: LÄMPÖTILA: 32.30  °C
 export const regexCapturePatterns = {
   colonSeparatedKeyValuePair: (term: string) =>
-    new RegExp(`(?:${term}:\\s*)${untilEndOfLineCaptureGroup}`, "u"),
+    new RegExp(`(?:${term}:\\s*)${untilEndOfLineCaptureGroup}`, 'u'),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
       "version": "0.0.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@aws-cdk/aws-elasticsearch": "1.173.0",
-        "@aws-cdk/custom-resources": "1.173.0",
-        "@aws-sdk/client-opensearch": "3.171.0",
-        "@aws-sdk/credential-provider-node": "3.171.0",
+        "@aws-cdk/aws-elasticsearch": "^1.173.0",
+        "@aws-cdk/custom-resources": "^1.173.0",
+        "@aws-sdk/client-opensearch": "^3.171.0",
+        "@aws-sdk/credential-provider-node": "^3.171.0",
         "@opensearch-project/opensearch": "^2.0.0",
-        "aws-cdk-lib": "2.42.0",
+        "aws-cdk-lib": "^2.42.0",
         "aws-lambda": "^1.0.7",
         "aws-opensearch-connector": "^1.1.0",
         "constructs": "^10.1.106",
+        "date-fns": "^2.29.3",
         "zod": "^3.19.1"
       },
       "devDependencies": {
@@ -4382,6 +4383,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -13358,6 +13371,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "aws-lambda": "^1.0.7",
     "aws-opensearch-connector": "^1.1.0",
     "constructs": "^10.1.106",
+    "date-fns": "^2.29.3",
     "zod": "^3.19.1"
   }
 }


### PR DESCRIPTION
Introduces bare-bones data type parsing to parser to get data types correctly in the data base. The Open Search now relies on [dynamic mapping](https://opensearch.org/docs/1.3/opensearch/mappings/#dynamic-mapping) to set index field types. In extractionSpec each item can have optional parseAs property with possible values of integer, float, date.

This is not yet a fully-fledged solution (especially date parsing needs more consideration).

Sorry for the single quotes/double quotes mess.