### PR TITLE
Feature: RAITA-53 S3 file access via cognito auth

### DIFF
--- a/lambda/s3urlGenerator/s3UrlGenerator.ts
+++ b/lambda/s3urlGenerator/s3UrlGenerator.ts
@@ -1,0 +1,80 @@
+import { APIGatewayEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { S3 } from 'aws-sdk';
+
+class RaitaLambdaException extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+/**
+ * Generates a pre-signed url for a file in S3 bucket
+ * Currently takes input in the POST request body
+ */
+export async function handleFileRequest(
+  event: APIGatewayEvent,
+  _context: Context,
+): Promise<APIGatewayProxyResult> {
+  const { pathParameters, body } = event;
+  const s3 = new S3();
+  try {
+    const dataBucket = process.env.DATA_BUCKET;
+    if (!dataBucket) {
+      throw new Error('Data bucket not specified.');
+    }
+    const requestBody = body ? JSON.parse(body) : undefined;
+    if (!requestBody?.key) {
+      throw new Error('path parameter key does not exist');
+    }
+    const { key } = requestBody;
+
+    // Check if file exists
+    const exists = await s3
+      .headObject({
+        Bucket: dataBucket,
+        Key: key,
+      })
+      .promise();
+
+    if (!exists) {
+      throw new RaitaLambdaException('Invalid input', 400);
+    }
+
+    // Create pre-signed url
+    const url = s3.getSignedUrl('getObject', {
+      Bucket: dataBucket,
+      Key: key,
+      Expires: 30,
+    });
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(
+        {
+          url,
+        },
+        null,
+        2,
+      ),
+    };
+  } catch (err: unknown) {
+    const errorMessage =
+      ((err instanceof Error || err instanceof RaitaLambdaException) &&
+        err.message) ||
+      (typeof err === 'string' && err) ||
+      'An error occurred.';
+    return {
+      statusCode:
+        (err instanceof RaitaLambdaException && err.statusCode) || 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: errorMessage }, null, 2),
+    };
+  }
+}

--- a/lib/raita-gateway.ts
+++ b/lib/raita-gateway.ts
@@ -1,0 +1,73 @@
+import { Duration, NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import {
+  AuthorizationType,
+  CognitoUserPoolsAuthorizer,
+  LambdaIntegration,
+  RestApi,
+} from 'aws-cdk-lib/aws-apigateway';
+import { Role } from 'aws-cdk-lib/aws-iam';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import * as path from 'path';
+import { UserPool } from 'aws-cdk-lib/aws-cognito';
+
+interface ResourceNestedStackProps extends NestedStackProps {
+  readonly dataBucket: Bucket;
+  readonly lambdaServiceRole: Role;
+  readonly userPool: UserPool;
+}
+
+export class RaitaGatewayStack extends NestedStack {
+  constructor(scope: Construct, props: ResourceNestedStackProps) {
+    super(scope, 'GatewayStack', props);
+
+    const restApi = new RestApi(this, 'RaitaApi', {
+      deploy: true,
+    });
+
+    const auth = new CognitoUserPoolsAuthorizer(this, 'raitaApiAuthorizer', {
+      cognitoUserPools: [props.userPool],
+    });
+
+    const urlGenerator = this.createS3urlGenerator({
+      name: 'fileAccessHandler',
+      lambdaRole: props.lambdaServiceRole,
+      dataBucket: props.dataBucket,
+    });
+
+    restApi.root
+      .addResource('files')
+      .addMethod('POST', new LambdaIntegration(urlGenerator), {
+        methodResponses: [{ statusCode: '200' }],
+        authorizer: auth,
+        authorizationType: AuthorizationType.COGNITO,
+      });
+  }
+
+  /**
+   * Returns lambda function that generates presigned urls
+   */
+  private createS3urlGenerator({
+    name,
+    dataBucket,
+    lambdaRole,
+  }: {
+    name: string;
+    dataBucket: Bucket;
+    lambdaRole: Role;
+  }) {
+    return new NodejsFunction(this, name, {
+      memorySize: 1024,
+      timeout: Duration.seconds(5),
+      runtime: Runtime.NODEJS_16_X,
+      handler: 'handleFileRequest',
+      entry: path.join(__dirname, `../lambda/s3UrlGenerator/s3UrlGenerator.ts`),
+      environment: {
+        DATA_BUCKET: dataBucket.bucketName,
+      },
+      role: lambdaRole,
+    });
+  }
+}

--- a/lib/raita-gateway.ts
+++ b/lib/raita-gateway.ts
@@ -40,7 +40,11 @@ export class RaitaGatewayStack extends NestedStack {
     restApi.root
       .addResource('files')
       .addMethod('POST', new LambdaIntegration(urlGenerator), {
-        methodResponses: [{ statusCode: '200' }],
+        methodResponses: [
+          { statusCode: '200' },
+          { statusCode: '400' },
+          { statusCode: '500' },
+        ],
         authorizer: auth,
         authorizationType: AuthorizationType.COGNITO,
       });

--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -174,6 +174,7 @@ export class RaitaStack extends Stack {
       '/*';
 
     // TODO: Identify parameters to move to environment (and move)
+    // TODO: Environment dependent removal policy
     return new opensearch.Domain(this, domainName, {
       version: opensearch.EngineVersion.OPENSEARCH_1_0,
       ebs: {
@@ -211,6 +212,7 @@ export class RaitaStack extends Stack {
     });
   }
 
+  // TODO: Environment dependent removal policy
   private createUserPool(applicationPrefix: string) {
     const userPool = new UserPool(this, applicationPrefix + 'UserPool', {
       userPoolName: applicationPrefix + ' User Pool',
@@ -231,8 +233,7 @@ export class RaitaStack extends Stack {
 
   /**
    * Creates a data bucket for the stacks
-   * TODO: Resolve if okay to delete bucket and objects
-   * when stack deleted (removalPolicy, autoDeleteObjects below)
+   * TODO: Environment dependent removal policy (and autoDeleteObjects)
    */
   private createBucket(bucketName: string) {
     return new s3.Bucket(this, bucketName, {

--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -29,7 +29,7 @@ import {
 import { Construct } from 'constructs';
 
 import * as path from 'path';
-import getConfig from '../lambda/config';
+import { RaitaGatewayStack } from './raita-gateway';
 
 export class RaitaStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -89,6 +89,13 @@ export class RaitaStack extends Stack {
       lambdaRole: lambdaServiceRole,
     });
 
+    // Create API Gateway
+    new RaitaGatewayStack(this, {
+      dataBucket,
+      lambdaServiceRole,
+      userPool,
+    });
+
     // Grant lambda read to configuration bucket
     configurationBucket.grantRead(handleMermecFileEvents);
 
@@ -141,6 +148,7 @@ export class RaitaStack extends Stack {
 
   /**
    * Creates OpenSearch domain
+   * TODO: Remove removalPolicy OR make it environment dependent
    */
   private createOpenSearchDomain({
     domainName,
@@ -172,6 +180,7 @@ export class RaitaStack extends Stack {
         volumeSize: 10,
         volumeType: ec2.EbsDeviceVolumeType.GENERAL_PURPOSE_SSD,
       },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       capacity: {
         dataNodes: 1,
         dataNodeInstanceType: 't3.small.search',
@@ -206,6 +215,7 @@ export class RaitaStack extends Stack {
     const userPool = new UserPool(this, applicationPrefix + 'UserPool', {
       userPoolName: applicationPrefix + ' User Pool',
       selfSignUpEnabled: false,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       signInAliases: {
         username: true,
         email: true,
@@ -219,6 +229,11 @@ export class RaitaStack extends Stack {
     return userPool;
   }
 
+  /**
+   * Creates a data bucket for the stacks
+   * TODO: Resolve if okay to delete bucket and objects
+   * when stack deleted (removalPolicy, autoDeleteObjects below)
+   */
   private createBucket(bucketName: string) {
     return new s3.Bucket(this, bucketName, {
       versioned: true,


### PR DESCRIPTION
Base implementation for generating pre-signed urls (introducing Api Gateway and url generating lambda). Enables a Cognito user to get a pre-signed url to a S3 file.

Removal policy for stateful resources (S3 buckets, OpenSearch domain and User pool) has been set to DESTROY (previously this was set only for S3 buckets).