### PR TITLE
Feature/RAITA-113 Add Certificate and Domain to Cloudfront

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,2 +1,3 @@
 export const SSM_CLOUDFRONT_CERTIFICATE_ARN =
   'raita-cloudfront-certificate-arn';
+export const SSM_CLOUDFRONT_DOMAIN_NAME = 'raita-cloudfront-domain-name';

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,0 +1,2 @@
+export const SSM_CLOUDFRONT_CERTIFICATE_ARN =
+  'raita-cloudfront-certificate-arn';

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,10 @@
 import { getEnvOrFail } from '../utils';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 // import { Construct } from '@aws-cdk/core';
-import { SSM_CLOUDFRONT_CERTIFICATE_ARN } from '../constants';
+import {
+  SSM_CLOUDFRONT_CERTIFICATE_ARN,
+  SSM_CLOUDFRONT_DOMAIN_NAME,
+} from '../constants';
 import { Construct } from 'constructs';
 
 export type RaitaEnvironment = typeof environments[keyof typeof environments];
@@ -70,5 +73,9 @@ export const getPipelineConfig = () => {
 export const getRaitaStackConfig = (scope: Construct) => ({
   parserConfigurationFile: 'extractionSpec.json',
   openSearchMetadataIndex: 'metadata-index',
-  certificate: getSSMParameter(scope, SSM_CLOUDFRONT_CERTIFICATE_ARN),
+  cloudfrontCertificateArn: getSSMParameter(
+    scope,
+    SSM_CLOUDFRONT_CERTIFICATE_ARN,
+  ),
+  cloudfrontDomainName: getSSMParameter(scope, SSM_CLOUDFRONT_DOMAIN_NAME),
 });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,8 @@
 import { getEnvOrFail } from '../utils';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+// import { Construct } from '@aws-cdk/core';
+import { SSM_CLOUDFRONT_CERTIFICATE_ARN } from '../constants';
+import { Construct } from 'constructs';
 
 export type RaitaEnvironment = typeof environments[keyof typeof environments];
 
@@ -16,6 +20,10 @@ const productionBranch = 'prod';
 const productionStackId = productionBranch;
 const developmentMainBranch = 'main';
 const developmentMainStackId = developmentMainBranch;
+
+// Returns token that resolves during deployment to SSM parameter value
+const getSSMParameter = (scope: Construct, parameterName: string) =>
+  ssm.StringParameter.valueForStringParameter(scope, parameterName);
 
 const getStackId = (branch: string): string => {
   const stackId = getEnvOrFail('STACK_ID');
@@ -59,7 +67,8 @@ export const getPipelineConfig = () => {
 // RaitaStack specific configuration
 // These values are used solely by metadata parser
 // Pending possible move to SSM Parameter Store (after discussion)
-export const getRaitaStackConfig = () => ({
+export const getRaitaStackConfig = (scope: Construct) => ({
   parserConfigurationFile: 'extractionSpec.json',
   openSearchMetadataIndex: 'metadata-index',
+  certificate: getSSMParameter(scope, SSM_CLOUDFRONT_CERTIFICATE_ARN),
 });

--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -41,7 +41,7 @@ import * as path from 'path';
 import { RaitaGatewayStack } from './raita-gateway';
 import { getRaitaStackConfig, RaitaEnvironment } from './config';
 import { getRemovalPolicy } from './utils';
-import { FrontendInfraStack } from './frontend-infra';
+import { CloudfrontStack } from './cloudfront';
 
 interface RaitaStackProps extends StackProps {
   readonly raitaEnv: RaitaEnvironment;
@@ -168,9 +168,11 @@ export class RaitaStack extends Stack {
     });
 
     // Create frontend infrastucture
-    new FrontendInfraStack(this, 'stack-fe', {
+    new CloudfrontStack(this, 'stack-fe', {
       raitaStackId: this.#stackId,
       raitaEnv: raitaEnv,
+      cloudfrontCertificateArn: config.cloudfrontCertificateArn,
+      cloudfrontDomainName: config.cloudfrontDomainName,
     });
 
     // Grant lambda read to configuration bucket

--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -35,6 +35,8 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+
 import * as path from 'path';
 import { RaitaGatewayStack } from './raita-gateway';
 import { getRaitaStackConfig, RaitaEnvironment } from './config';
@@ -56,7 +58,7 @@ export class RaitaStack extends Stack {
     const cognitoDomainPrefix = this.#stackId;
 
     // OPEN: Move to parameter store?
-    const config = getRaitaStackConfig(scope);
+    const config = getRaitaStackConfig(this);
 
     // Create buckets
     const dataBucket = this.createBucket({

--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -34,6 +34,7 @@ import {
   FederatedPrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+
 import * as path from 'path';
 import { RaitaGatewayStack } from './raita-gateway';
 import { getRaitaStackConfig, RaitaEnvironment } from './config';
@@ -55,7 +56,7 @@ export class RaitaStack extends Stack {
     const cognitoDomainPrefix = this.#stackId;
 
     // OPEN: Move to parameter store?
-    const config = getRaitaStackConfig();
+    const config = getRaitaStackConfig(scope);
 
     // Create buckets
     const dataBucket = this.createBucket({


### PR DESCRIPTION
Adds certificate and domain name to Cloudfront.

Not fully tested implementation: In feature stack deployment fails due to domain name being incorrectly configured DNS record that points to another CloudFront distribution (main stack cloudfront distribution). There seems to be no to test this in feature branch before merging to main.