### PR TITLE
fix/RAITA-155 Change os name to init fresh vpc os

### DIFF
--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -64,7 +64,7 @@ export class RaitaStack extends Stack {
 
     // Create and configure OpenSearch domain
     const openSearchDomain = this.createOpenSearchDomain({
-      name: 'raita',
+      name: 'raitadb',
       raitaEnv: props.raitaEnv,
       vpc: raitaVPC,
     });


### PR DESCRIPTION
Pull request changes the raita open search domain name to deploy new instance into vpc (and to remove old non-vpc instance).