### PR TITLE
 fix(stack): RAITA-143 add data reception bucket alb name conflict

### DIFF
--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -87,7 +87,7 @@ export class RaitaApiStack extends NestedStack {
     // ALB for API
     this.createlAlb({
       raitaStackIdentifier: raitaStackIdentifier,
-      name: 'api',
+      name: 'raita-api',
       vpc,
       listenerTargets: albLambdaTargets,
     });


### PR DESCRIPTION
Resolves alb resource naming conflict by slightly changing the resource name.