### PR TITLE
refactor: RAITA-154 temporary open search and dependent resource removal

### DIFF
--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -17,10 +17,10 @@ import { Domain } from 'aws-cdk-lib/aws-opensearchservice';
 interface RaitaApiStackProps extends NestedStackProps {
   readonly raitaStackIdentifier: string;
   readonly raitaEnv: RaitaEnvironment;
-  readonly inspectionDataBucket: Bucket;
+  // readonly inspectionDataBucket: Bucket;
   readonly openSearchMetadataIndex: string;
   readonly vpc: ec2.IVpc;
-  readonly openSearchDomain: Domain;
+  // readonly openSearchDomain: Domain;
 }
 
 type ListenerTargetLambdas = {
@@ -43,53 +43,53 @@ export class RaitaApiStack extends NestedStack {
       raitaStackIdentifier,
       openSearchMetadataIndex,
       vpc,
-      inspectionDataBucket,
-      openSearchDomain,
+      // inspectionDataBucket,
+      // openSearchDomain,
     } = props;
 
-    this.raitaApiLambdaServiceRole = createRaitaServiceRole({
-      scope: this,
-      name: 'RaitaApiLambdaServiceRole',
-      servicePrincipal: 'lambda.amazonaws.com',
-      policyName: 'service-role/AWSLambdaVPCAccessExecutionRole',
-      raitaStackIdentifier,
-    });
-    openSearchDomain.grantIndexRead(
-      openSearchMetadataIndex,
-      this.raitaApiLambdaServiceRole,
-    );
-    inspectionDataBucket.grantRead(this.raitaApiLambdaServiceRole);
+    // this.raitaApiLambdaServiceRole = createRaitaServiceRole({
+    //   scope: this,
+    //   name: 'RaitaApiLambdaServiceRole',
+    //   servicePrincipal: 'lambda.amazonaws.com',
+    //   policyName: 'service-role/AWSLambdaVPCAccessExecutionRole',
+    //   raitaStackIdentifier,
+    // });
+    // openSearchDomain.grantIndexRead(
+    //   openSearchMetadataIndex,
+    //   this.raitaApiLambdaServiceRole,
+    // );
+    // inspectionDataBucket.grantRead(this.raitaApiLambdaServiceRole);
 
-    // Create handler lambdas
-    const handleFileRequestFn = this.createFileRequestHandler({
-      name: 'api-handler-file',
-      raitaStackIdentifier,
-      lambdaRole: this.raitaApiLambdaServiceRole,
-      dataBucket: inspectionDataBucket,
-      vpc,
-    });
+    // // Create handler lambdas
+    // const handleFileRequestFn = this.createFileRequestHandler({
+    //   name: 'api-handler-file',
+    //   raitaStackIdentifier,
+    //   lambdaRole: this.raitaApiLambdaServiceRole,
+    //   dataBucket: inspectionDataBucket,
+    //   vpc,
+    // });
 
-    this.handleFilesRequestFn = this.createFilesRequestHandler({
-      name: 'api-handler-files',
-      raitaStackIdentifier,
-      lambdaRole: this.raitaApiLambdaServiceRole,
-      openSearchDomainEndpoint: openSearchDomain.domainEndpoint,
-      openSearchMetadataIndex,
-      vpc,
-    });
+    // this.handleFilesRequestFn = this.createFilesRequestHandler({
+    //   name: 'api-handler-files',
+    //   raitaStackIdentifier,
+    //   lambdaRole: this.raitaApiLambdaServiceRole,
+    //   openSearchDomainEndpoint: openSearchDomain.domainEndpoint,
+    //   openSearchMetadataIndex,
+    //   vpc,
+    // });
 
-    // Add all lambdas here to add as alb targets
-    const albLambdaTargets: ListenerTargetLambdas[] = [
-      { lambda: handleFileRequestFn, priority: 90, path: ['/file'] },
-      { lambda: this.handleFilesRequestFn, priority: 100, path: ['/files'] },
-    ];
+    // // Add all lambdas here to add as alb targets
+    // const albLambdaTargets: ListenerTargetLambdas[] = [
+    //   { lambda: handleFileRequestFn, priority: 90, path: ['/file'] },
+    //   { lambda: this.handleFilesRequestFn, priority: 100, path: ['/files'] },
+    // ];
 
     // ALB for API
     this.createlAlb({
       raitaStackIdentifier: raitaStackIdentifier,
       name: 'raita-api',
       vpc,
-      listenerTargets: albLambdaTargets,
+      listenerTargets: [], // albLambdaTargets,
     });
   }
 

--- a/lib/raita-application.ts
+++ b/lib/raita-application.ts
@@ -28,7 +28,7 @@ interface ApplicationStackProps extends NestedStackProps {
  * OpenSearch documentation available at: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html
  */
 export class ApplicationStack extends NestedStack {
-  public readonly openSearchDomain: opensearch.Domain;
+  // public readonly openSearchDomain: opensearch.Domain;
 
   constructor(scope: Construct, id: string, props: ApplicationStackProps) {
     super(scope, id, props);
@@ -41,27 +41,27 @@ export class ApplicationStack extends NestedStack {
     } = props;
 
     // Create and configure OpenSearch domain
-    this.openSearchDomain = this.createOpenSearchDomain({
-      name: 'db',
-      raitaEnv: raitaEnv,
-      vpc,
-      raitaStackIdentifier,
-    });
+    // this.openSearchDomain = this.createOpenSearchDomain({
+    //   name: 'db',
+    //   raitaEnv: raitaEnv,
+    //   vpc,
+    //   raitaStackIdentifier,
+    // });
 
     // Create data processing resources
-    const dataProcessStack = new DataProcessStack(this, 'stack-dataprocess', {
-      raitaStackIdentifier: raitaStackIdentifier,
-      raitaEnv,
-      vpc,
-      openSearchDomain: this.openSearchDomain,
-      openSearchMetadataIndex: openSearchMetadataIndex,
-      parserConfigurationFile: parserConfigurationFile,
-    });
+    // const dataProcessStack = new DataProcessStack(this, 'stack-dataprocess', {
+    //   raitaStackIdentifier: raitaStackIdentifier,
+    //   raitaEnv,
+    //   vpc,
+    //   openSearchDomain: this.openSearchDomain,
+    //   openSearchMetadataIndex: openSearchMetadataIndex,
+    //   parserConfigurationFile: parserConfigurationFile,
+    // });
 
     // Create API Gateway
     const raitaApi = new RaitaApiStack(this, 'stack-api', {
-      inspectionDataBucket: dataProcessStack.inspectionDataBucket,
-      openSearchDomain: this.openSearchDomain,
+      // inspectionDataBucket: dataProcessStack.inspectionDataBucket,
+      // openSearchDomain: this.openSearchDomain,
       raitaEnv,
       raitaStackIdentifier: raitaStackIdentifier,
       openSearchMetadataIndex: openSearchMetadataIndex,
@@ -69,34 +69,34 @@ export class ApplicationStack extends NestedStack {
     });
 
     // Grant data processor lambdas permissions to call OpenSearch endpoints
-    this.createManagedPolicy({
-      name: 'DataProcessOpenSearchHttpPolicy',
-      raitaStackIdentifier,
-      serviceRoles: [dataProcessStack.dataProcessorLambdaServiceRole],
-      resources: [this.openSearchDomain.domainArn],
-      actions: ['es:ESHttpGet', 'es:ESHttpPost', 'es:ESHttpPut'],
-    });
+    // this.createManagedPolicy({
+    //   name: 'DataProcessOpenSearchHttpPolicy',
+    //   raitaStackIdentifier,
+    //   serviceRoles: [dataProcessStack.dataProcessorLambdaServiceRole],
+    //   resources: [this.openSearchDomain.domainArn],
+    //   actions: ['es:ESHttpGet', 'es:ESHttpPost', 'es:ESHttpPut'],
+    // });
 
-    // Grant api lambdas permissions to call OpenSearch endpoints
-    this.createManagedPolicy({
-      name: 'ApiOpenSearchHttpPolicy',
-      raitaStackIdentifier,
-      serviceRoles: [raitaApi.raitaApiLambdaServiceRole],
-      resources: [this.openSearchDomain.domainArn],
-      actions: ['es:ESHttpGet', 'es:ESHttpPost', 'es:ESHttpPut'],
-    });
+    // // Grant api lambdas permissions to call OpenSearch endpoints
+    // this.createManagedPolicy({
+    //   name: 'ApiOpenSearchHttpPolicy',
+    //   raitaStackIdentifier,
+    //   serviceRoles: [raitaApi.raitaApiLambdaServiceRole],
+    //   resources: [this.openSearchDomain.domainArn],
+    //   actions: ['es:ESHttpGet', 'es:ESHttpPost', 'es:ESHttpPut'],
+    // });
 
-    // Allow traffic from lambdas to OpenSearch
-    this.openSearchDomain.connections.allowFrom(
-      dataProcessStack.handleInspectionFileEventFn,
-      Port.allTraffic(),
-      'Allows parser lambda to connect to Opensearch.',
-    );
-    this.openSearchDomain.connections.allowFrom(
-      raitaApi.handleFilesRequestFn,
-      Port.allTraffic(),
-      'Allows parser lambda to connect to Opensearch.',
-    );
+    // // Allow traffic from lambdas to OpenSearch
+    // this.openSearchDomain.connections.allowFrom(
+    //   dataProcessStack.handleInspectionFileEventFn,
+    //   Port.allTraffic(),
+    //   'Allows parser lambda to connect to Opensearch.',
+    // );
+    // this.openSearchDomain.connections.allowFrom(
+    //   raitaApi.handleFilesRequestFn,
+    //   Port.allTraffic(),
+    //   'Allows parser lambda to connect to Opensearch.',
+    // );
   }
 
   /**


### PR DESCRIPTION
Temporarily removes OpenSearch and dependent resources from AWS infra to enable creation of application load balancer within vpc (to bypass error "Exceeded attemps to wait" originating from os).