### PR TITLE
refactor: RAITA-154 return of open search and dependent components

### DIFF
--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -17,10 +17,10 @@ import { Domain } from 'aws-cdk-lib/aws-opensearchservice';
 interface RaitaApiStackProps extends NestedStackProps {
   readonly raitaStackIdentifier: string;
   readonly raitaEnv: RaitaEnvironment;
-  // readonly inspectionDataBucket: Bucket;
+  readonly inspectionDataBucket: Bucket;
   readonly openSearchMetadataIndex: string;
   readonly vpc: ec2.IVpc;
-  // readonly openSearchDomain: Domain;
+  readonly openSearchDomain: Domain;
 }
 
 type ListenerTargetLambdas = {
@@ -43,53 +43,53 @@ export class RaitaApiStack extends NestedStack {
       raitaStackIdentifier,
       openSearchMetadataIndex,
       vpc,
-      // inspectionDataBucket,
-      // openSearchDomain,
+      inspectionDataBucket,
+      openSearchDomain,
     } = props;
 
-    // this.raitaApiLambdaServiceRole = createRaitaServiceRole({
-    //   scope: this,
-    //   name: 'RaitaApiLambdaServiceRole',
-    //   servicePrincipal: 'lambda.amazonaws.com',
-    //   policyName: 'service-role/AWSLambdaVPCAccessExecutionRole',
-    //   raitaStackIdentifier,
-    // });
-    // openSearchDomain.grantIndexRead(
-    //   openSearchMetadataIndex,
-    //   this.raitaApiLambdaServiceRole,
-    // );
-    // inspectionDataBucket.grantRead(this.raitaApiLambdaServiceRole);
+    this.raitaApiLambdaServiceRole = createRaitaServiceRole({
+      scope: this,
+      name: 'RaitaApiLambdaServiceRole',
+      servicePrincipal: 'lambda.amazonaws.com',
+      policyName: 'service-role/AWSLambdaVPCAccessExecutionRole',
+      raitaStackIdentifier,
+    });
+    openSearchDomain.grantIndexRead(
+      openSearchMetadataIndex,
+      this.raitaApiLambdaServiceRole,
+    );
+    inspectionDataBucket.grantRead(this.raitaApiLambdaServiceRole);
 
-    // // Create handler lambdas
-    // const handleFileRequestFn = this.createFileRequestHandler({
-    //   name: 'api-handler-file',
-    //   raitaStackIdentifier,
-    //   lambdaRole: this.raitaApiLambdaServiceRole,
-    //   dataBucket: inspectionDataBucket,
-    //   vpc,
-    // });
+    // Create handler lambdas
+    const handleFileRequestFn = this.createFileRequestHandler({
+      name: 'api-handler-file',
+      raitaStackIdentifier,
+      lambdaRole: this.raitaApiLambdaServiceRole,
+      dataBucket: inspectionDataBucket,
+      vpc,
+    });
 
-    // this.handleFilesRequestFn = this.createFilesRequestHandler({
-    //   name: 'api-handler-files',
-    //   raitaStackIdentifier,
-    //   lambdaRole: this.raitaApiLambdaServiceRole,
-    //   openSearchDomainEndpoint: openSearchDomain.domainEndpoint,
-    //   openSearchMetadataIndex,
-    //   vpc,
-    // });
+    this.handleFilesRequestFn = this.createFilesRequestHandler({
+      name: 'api-handler-files',
+      raitaStackIdentifier,
+      lambdaRole: this.raitaApiLambdaServiceRole,
+      openSearchDomainEndpoint: openSearchDomain.domainEndpoint,
+      openSearchMetadataIndex,
+      vpc,
+    });
 
-    // // Add all lambdas here to add as alb targets
-    // const albLambdaTargets: ListenerTargetLambdas[] = [
-    //   { lambda: handleFileRequestFn, priority: 90, path: ['/file'] },
-    //   { lambda: this.handleFilesRequestFn, priority: 100, path: ['/files'] },
-    // ];
+    // Add all lambdas here to add as alb targets
+    const albLambdaTargets: ListenerTargetLambdas[] = [
+      { lambda: handleFileRequestFn, priority: 90, path: ['/file'] },
+      { lambda: this.handleFilesRequestFn, priority: 100, path: ['/files'] },
+    ];
 
     // ALB for API
     this.createlAlb({
       raitaStackIdentifier: raitaStackIdentifier,
       name: 'raita-api',
       vpc,
-      listenerTargets: [], // albLambdaTargets,
+      listenerTargets: albLambdaTargets,
     });
   }
 

--- a/lib/raita-application.ts
+++ b/lib/raita-application.ts
@@ -28,8 +28,6 @@ interface ApplicationStackProps extends NestedStackProps {
  * OpenSearch documentation available at: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html
  */
 export class ApplicationStack extends NestedStack {
-  // public readonly openSearchDomain: opensearch.Domain;
-
   constructor(scope: Construct, id: string, props: ApplicationStackProps) {
     super(scope, id, props);
     const {

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -6,7 +6,7 @@ import { Role } from 'aws-cdk-lib/aws-iam';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { S3EventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { IVpc, SubnetType } from 'aws-cdk-lib/aws-ec2';
+import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Domain } from 'aws-cdk-lib/aws-opensearchservice';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';


### PR DESCRIPTION
In this sequel to RAITA-154 saga OpenSearch and dependent resources return (hopefully) to the company of other AWS infra resources.

Additionally small clean-ups: Removal of unused import from raita-data-process.ts, removal of unnecessary class member variable from raita-application.ts