### PR TITLE
fix: buxfixes for demo

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  swcMinify: false,
+  compiler: {
+    removeConsole: false,
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -352,10 +352,14 @@ const ReportsIndex: NextPage = () => {
                                 size="sm"
                                 label={t('common:download')}
                                 onClick={() => {
-                                  getFileUrl.mutate({
+                                  const opts = {
                                     key: doc.key,
                                     fileName: doc.file_name,
-                                  });
+                                  };
+
+                                  console.log('getFileUrl', { opts });
+
+                                  getFileUrl.mutate(opts);
                                 }}
                               />
                             </footer>

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -321,7 +321,7 @@ const ReportsIndex: NextPage = () => {
                         <li key={`result-${ix}`}>
                           <article className="py-2 space-y-2">
                             <header>
-                              {doc.fileName}{' '}
+                              {doc.file_name}
                               <span className="text-xs">
                                 Score=
                                 <span className="font-mono">{it._score}</span>
@@ -352,7 +352,10 @@ const ReportsIndex: NextPage = () => {
                                 size="sm"
                                 label={t('common:download')}
                                 onClick={() => {
-                                  getFileUrl.mutate(doc.fileName);
+                                  getFileUrl.mutate({
+                                    key: doc.key,
+                                    fileName: doc.file_name,
+                                  });
                                 }}
                               />
                             </footer>

--- a/frontend/shared/config.ts
+++ b/frontend/shared/config.ts
@@ -5,3 +5,8 @@
 export const openSearch = {
   indexName: 'metadata-index-v2',
 } as const;
+
+export const baseURL =
+  process.env.NEXT_PUBLIC_API_BASEURL || process.env.API_BASEURL || '/api';
+
+console.log({ baseURL });

--- a/frontend/shared/hooks.ts
+++ b/frontend/shared/hooks.ts
@@ -31,6 +31,8 @@ export function useMetadataQuery() {
  */
 export function useSearch() {
   return useMutation((query: MsearchBody) => {
+    console.assert(query, 'Given search query is invalid; %o', { query });
+
     return apiClient
       .post<{ result: { body: SearchResponse<IDocument> } }>('/files', query)
       .then(R.prop('data'))
@@ -41,8 +43,14 @@ export function useSearch() {
 export function useFileQuery(saveFile = true) {
   return useMutation((opts: UseFileQueryArgs) => {
     const { key, fileName } = opts;
+    console.assert(
+      key,
+      'The given `key` fpr `useFileQuery` is invalid; %s',
+      key,
+    );
+
     return getFile(key).then(res => {
-      if (saveFile) saveAs(res.url, key);
+      if (saveFile) saveAs(res.url, fileName);
       return res;
     });
   });

--- a/frontend/shared/hooks.ts
+++ b/frontend/shared/hooks.ts
@@ -39,13 +39,19 @@ export function useSearch() {
 }
 
 export function useFileQuery(saveFile = true) {
-  return useMutation((key: string) => {
+  return useMutation((opts: UseFileQueryArgs) => {
+    const { key, fileName } = opts;
     return getFile(key).then(res => {
       if (saveFile) saveAs(res.url, key);
       return res;
     });
   });
 }
+
+type UseFileQueryArgs = {
+  key: string;
+  fileName?: string;
+};
 
 // #endregion
 

--- a/frontend/shared/rest.ts
+++ b/frontend/shared/rest.ts
@@ -1,12 +1,12 @@
 import A from 'axios';
+import { baseURL } from 'shared/config';
 
 /**
  * API client for use in calling the REST API endpoint
  */
-export const apiClient = A.create({
-  baseURL:
-    process.env.NEXT_PUBLIC_API_BASEURL || process.env.API_BASEURL || '/api',
-});
+export const apiClient = A.create({ baseURL: baseURL });
+
+console.log({ apiClient });
 
 //
 
@@ -16,13 +16,13 @@ export const apiClient = A.create({
  * @returns
  */
 export const getFiles = (q: object) =>
-  apiClient.post<GetFilesResult>('/files', q);
+  apiClient.post<GetFilesResult>('files', q);
 
 export const getFile = (key: string) =>
-  apiClient.post<GetSignedUrlResult>('/file', { key }).then(res => res.data);
+  apiClient.post<GetSignedUrlResult>('file', { key }).then(res => res.data);
 
 export const getMeta = () => {
-  return apiClient.get<GetMetaResult>('/meta').then(res => res.data);
+  return apiClient.get<GetMetaResult>('meta').then(res => res.data);
 };
 
 type GetFilesResult = {};
@@ -48,17 +48,6 @@ type MetaResultType = { reportType: string; count: number };
  * This is only used for the backend whiel running in a dev env, e.g. locally.
  * @deprecated Use @see {@link api} instead
  */
-export const client = A.create({
-  baseURL: process.env.ES_CONNSTRING,
-});
-
-/**
- * The REST client that's used for accessing the OpenSearch endpoint.
- * Configuration for requests should be placed here.
- * @deprecated Use @see {@link api} instead
- */
-export const webClient = A.create({
-  baseURL: '/api',
-});
+export const client = A.create({ baseURL });
 
 // #endregion

--- a/frontend/shared/rest.ts
+++ b/frontend/shared/rest.ts
@@ -6,8 +6,6 @@ import { baseURL } from 'shared/config';
  */
 export const apiClient = A.create({ baseURL: baseURL });
 
-console.log({ apiClient });
-
 //
 
 /**

--- a/frontend/shared/types.ts
+++ b/frontend/shared/types.ts
@@ -55,9 +55,11 @@ export interface ISearchResult<T> {
 //
 
 export interface IDocument {
-  fileName: string;
-  arn: string;
-  bucket: string;
+  key: string;
+  file_name: string;
+  bucket_arn: string;
+  bucket_name: string;
+  size: number;
   metadata: IDocumentMetadata;
 }
 


### PR DESCRIPTION
- Updated typedefs for ElasticSearch result documents
- Use correct `key` and `file_name` for requesting signed file URLs
- Disable optimizations temporarily to allow for convenient debugging on deployed software (minification off, `console.*` calls are not removed)