### PR TITLE
fix(parser): RAITA-165 s3 event special character handling

### DIFF
--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/contentDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/contentDataParser.ts
@@ -71,7 +71,7 @@ export const extractFileContentData = (
 /**
  * Returns hex encoded hash for given file input
  */
-export const calculateHash = (fileBody: string): ParseValueResult => {
+export const calculateHash = (fileBody: string): string => {
   const hash = createHash('sha256');
-  return { hash: hash.update(fileBody).digest('hex') };
+  return hash.update(fileBody).digest('hex');
 };

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -40,7 +40,7 @@ export const getRaitaLambdaError = (err: unknown) => ({
  */
 export const decodeUriString = (uriString: string) => {
   try {
-    return decodeURI(uriString);
+    return decodeURIComponent(uriString);
   } catch (error) {
     return uriString;
   }

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -46,6 +46,8 @@ export const decodeUriString = (uriString: string) => {
   }
 };
 
+export const decodeS3EventPropertyString = (s: string) => s.replace(/\+/g, ' ');
+
 export const getOpenSearchLambdaConfigOrFail = () => {
   const getEnv = getGetEnvWithPreassignedContext('Metadata parser lambda');
   return {

--- a/backend/types/index.ts
+++ b/backend/types/index.ts
@@ -12,6 +12,7 @@ export interface FileMetadataEntry {
   bucket_name: string;
   bucket_arn: string;
   metadata: ParseValueResult;
+  hash: string | undefined;
 }
 
 export interface IFileResult {


### PR DESCRIPTION
Pull request removes + characters from S3 key (file path in S3) with which AWS S3/event system has replaced spaces in the key. This has the following effects:
- the key is stored into the datebase without + characters replacing spaces
- all the meta data that is parsed from the folder tree and file name is cleaned from + characters (replaced with space).

If the folder path or the file name should contain intended + characters, these are now lost. This seems like quite an unlikely scenario and even in this case the loss of information would be small. 

More subtle approach regarding the meta data parsing would be to explicitly define in extractionSpect those pieces of meta data that should be cleaned from unwanted + charaters (this is left for possible future development).

Additinally the pull request

- replaces decodeUri with more appropriate decodeUriComponent
- removes hash from meta data (now stored directly under the doc, not within meta data)