### PR TITLE
feat(api): RAITA-170 add file type to meta endpoint

### DIFF
--- a/backend/adapters/openSearchRepository.ts
+++ b/backend/adapters/openSearchRepository.ts
@@ -69,4 +69,23 @@ export class OpenSearchRepository implements IMetadataStorageInterface {
     });
     return response;
   };
+
+  getFileTypes = async () => {
+    const client = await this.#openSearchClient.getClient();
+    const response = await client.search({
+      index: this.#dataIndex,
+      body: {
+        size: 0,
+        aggs: {
+          types: {
+            terms: {
+              field: 'metadata.file_type.keyword',
+              size: 10,
+            },
+          },
+        },
+      },
+    });
+    return response;
+  };
 }

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
@@ -60,7 +60,7 @@ export const extractFileNameData = (
       {},
     );
     return {
-      fileType: suffix,
+      file_type: suffix,
       ...specBasedMetadata,
     };
   } catch (error) {

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
@@ -1,5 +1,6 @@
 import { IExtractionSpec, ParseValueResult } from '../../../types';
 import { logger } from '../../../utils/logger';
+import { RaitaParseError } from '../../utils';
 import { parsePrimitive } from './parsePrimitives';
 
 // TODO: Remove this typeguard by improving types
@@ -13,50 +14,63 @@ export const extractFileNameData = (
   fileName: string,
   fileNamePartLabels: IExtractionSpec['fileNameExtractionSpec'],
 ) => {
-  const fileNameParts = fileName.split('.');
-  if (fileNameParts.length !== 2) {
-    logger.logParsingException(`Unexpected filename: ${fileName}`);
-    return {};
-  }
-  const [baseName, suffix] = fileNameParts;
-
-  if (!suffixIsKnown(suffix)) {
-    logger.logParsingException(`Unexpected suffix in file: ${fileName}`);
-    return {};
-  }
-
-  const labels = fileNamePartLabels[suffix];
-
-  const fileBaseNameParts = baseName.split('_');
-  const lastFileBaseNamePart = fileBaseNameParts[fileBaseNameParts.length - 1];
-  const labelCount = Object.keys(labels).length;
-  const expectedFileNameLength =
-    lastFileBaseNamePart === EMPTY_FILE_INDICATOR ? labelCount + 1 : labelCount;
-
-  if (fileBaseNameParts.length !== expectedFileNameLength) {
-    logger.logParsingException(
-      `Unexpected number of parts in file name. Expected ${expectedFileNameLength} but got ${fileBaseNameParts.length} for file ${fileName}. File name analysis not carried out.`,
+  try {
+    const fileNameParts = fileName.split('.');
+    if (fileNameParts.length !== 2) {
+      throw new RaitaParseError(`Unexpected file name structure: ${fileName}`);
+    }
+    const [baseName, suffix] = fileNameParts;
+    if (!suffixIsKnown(suffix)) {
+      throw new RaitaParseError(`Unexpected suffix in file name: ${fileName}`);
+    }
+    const labels = fileNamePartLabels[suffix];
+    const fileBaseNameParts = baseName.split('_');
+    const lastFileBaseNamePart =
+      fileBaseNameParts[fileBaseNameParts.length - 1];
+    const labelCount = Object.keys(labels).length;
+    // The file name may have empty file indicator in the end, increasing expected
+    // part count by one
+    const expectedFileNamePartCount =
+      lastFileBaseNamePart === EMPTY_FILE_INDICATOR
+        ? labelCount + 1
+        : labelCount;
+    if (fileBaseNameParts.length !== expectedFileNamePartCount) {
+      throw new RaitaParseError(
+        `Unexpected number of file name segments in ${fileName}. Expected ${expectedFileNamePartCount}, received ${fileBaseNameParts.length}.`,
+      );
+    }
+    const specBasedMetadata = fileBaseNameParts.reduce<ParseValueResult>(
+      (acc, cur, index) => {
+        // Handle the empty file indicator as special case.
+        // Implementation depends on this incicator being in the end of the string.
+        if (cur === EMPTY_FILE_INDICATOR) {
+          acc['isEmpty'] = true;
+          return acc;
+        }
+        // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
+        const { name, parseAs } = labels[index + 1];
+        if (name) {
+          const { key, value } = parseAs
+            ? parsePrimitive(name, cur, parseAs)
+            : { key: name, value: cur };
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {},
     );
-    return {};
+    return {
+      fileType: suffix,
+      ...specBasedMetadata,
+    };
+  } catch (error) {
+    // Currently just log file name parsing errors.
+    if (error instanceof RaitaParseError) {
+      logger.logParsingException(
+        `${error.message}. File name extraction skipped.`,
+      );
+      return {};
+    }
+    throw error;
   }
-  return fileBaseNameParts.reduce<ParseValueResult>((acc, cur, index) => {
-    // Handle the empty file indicator as special case.
-    // Implementation depends on this incicator being in the end of the string.
-    if (cur === EMPTY_FILE_INDICATOR) {
-      acc['isEmpty'] = true;
-      return acc;
-    }
-
-    // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
-    const { name, parseAs } = labels[index + 1];
-    if (name) {
-      const { key, value } = parseAs
-        ? parsePrimitive(name, cur, parseAs)
-        : { key: name, value: cur };
-      // TODO: AWS has replaced spaces in folder names with + character. To decide whether these should be
-      // replaced back to spaces.
-      acc[key] = value;
-    }
-    return acc;
-  }, {});
 };

--- a/backend/lambdas/raitaApi/handleMetaRequest/handleMetaRequestSchemas.ts
+++ b/backend/lambdas/raitaApi/handleMetaRequest/handleMetaRequestSchemas.ts
@@ -24,7 +24,7 @@ const BucketElementSchema = z.object({
 });
 
 // NOTE: This is INCOMPLETE schema typing of report type response
-export const ReportTypesSchema = z.object({
+export const AggregationsResponseSchema = z.object({
   aggregations: z.object({
     types: z.object({
       buckets: z.array(BucketElementSchema),

--- a/backend/ports/metadataPort.ts
+++ b/backend/ports/metadataPort.ts
@@ -52,4 +52,7 @@ export default class MetadataPort implements IMetadataStorageInterface {
   getReportTypes = () => {
     return this.#backend.getReportTypes();
   };
+  getFileTypes = () => {
+    return this.#backend.getFileTypes();
+  };
 }

--- a/backend/types/portDataStorage.ts
+++ b/backend/types/portDataStorage.ts
@@ -5,4 +5,5 @@ export interface IMetadataStorageInterface {
   queryOpenSearchMetadata: (query: any) => Promise<any>;
   getMetadataFields: () => Promise<any>;
   getReportTypes: () => Promise<any>;
+  getFileTypes: () => Promise<any>;
 }


### PR DESCRIPTION
Pull request makes file types available to frontend:

- parser now adds file suffix into meta data as file_type property
- meta endpoint now includes fileTypes property, returning information about file types in the data. The implementation is far from optimized, there is a Jira task 172 for improvements (combining getFileTypes/getReportTypes and/or parallelization of db requests).

Also a bit of cleaning of error handling in extractFileNameData function.