### PR TITLE
Feat: RAITA-186 meta endpoint new fields

### DIFF
--- a/backend/adapters/openSearch/openSearchRepository.ts
+++ b/backend/adapters/openSearch/openSearchRepository.ts
@@ -72,6 +72,21 @@ export class OpenSearchRepository implements IMetadataStorageInterface {
               field: 'metadata.file_type.keyword',
             },
           },
+          systems: {
+            terms: {
+              field: 'metadata.system.keyword',
+            },
+          },
+          track_numbers: {
+            terms: {
+              field: 'metadata.track_number.keyword',
+            },
+          },
+          track_parts: {
+            terms: {
+              field: 'metadata.track_part.keyword',
+            },
+          },
         },
       },
     });

--- a/backend/adapters/openSearch/openSearchResponseParser.ts
+++ b/backend/adapters/openSearch/openSearchResponseParser.ts
@@ -28,17 +28,17 @@ export class OpenSearchResponseParser {
       systems: this.transformAggregationsResult(
         aggregations,
         'systems',
-        'system',
+        'value',
       ),
       trackNumbers: this.transformAggregationsResult(
         aggregations,
-        'report_types',
-        'reportType',
+        'track_numbers',
+        'value',
       ),
       trackParts: this.transformAggregationsResult(
         aggregations,
         'track_parts',
-        'trackPart',
+        'value',
       ),
     };
   };

--- a/backend/adapters/openSearch/openSearchResponseParser.ts
+++ b/backend/adapters/openSearch/openSearchResponseParser.ts
@@ -19,27 +19,27 @@ export class OpenSearchResponseParser {
         aggregations,
         'report_types',
         'reportType',
-      ),
+      ) as Array<{ reportType: string; count: 1 }>,
       fileTypes: this.transformAggregationsResult(
         aggregations,
         'file_types',
         'fileType',
-      ),
+      ) as Array<{ fileType: string; count: 1 }>,
       systems: this.transformAggregationsResult(
         aggregations,
         'systems',
         'value',
-      ),
+      ) as Array<{ value: string; count: 1 }>,
       trackNumbers: this.transformAggregationsResult(
         aggregations,
         'track_numbers',
         'value',
-      ),
+      ) as Array<{ value: string; count: 1 }>,
       trackParts: this.transformAggregationsResult(
         aggregations,
         'track_parts',
         'value',
-      ),
+      ) as Array<{ value: string; count: 1 }>,
     };
   };
 

--- a/backend/adapters/openSearch/openSearchResponseParser.ts
+++ b/backend/adapters/openSearch/openSearchResponseParser.ts
@@ -1,5 +1,6 @@
 import {
   AggregationsResponseSchema,
+  AggregationsResponseSchemaType,
   FieldMappingsSchema,
 } from './openSearchResponseSchemas';
 
@@ -14,14 +15,31 @@ export class OpenSearchResponseParser {
     ).aggregations;
     // Bucket results are mapped to hide OpenSearch spesific naming from api users
     return {
-      reportTypes: aggregations.report_types.buckets.map(element => ({
-        reportType: element.key,
-        count: element.doc_count,
-      })),
-      fileTypes: aggregations.file_types.buckets.map(element => ({
-        fileType: element.key,
-        count: element.doc_count,
-      })),
+      reportTypes: this.transformAggregationsResult(
+        aggregations,
+        'report_types',
+        'reportType',
+      ),
+      fileTypes: this.transformAggregationsResult(
+        aggregations,
+        'file_types',
+        'fileType',
+      ),
+      systems: this.transformAggregationsResult(
+        aggregations,
+        'systems',
+        'system',
+      ),
+      trackNumbers: this.transformAggregationsResult(
+        aggregations,
+        'report_types',
+        'reportType',
+      ),
+      trackParts: this.transformAggregationsResult(
+        aggregations,
+        'track_parts',
+        'trackPart',
+      ),
     };
   };
 
@@ -41,4 +59,14 @@ export class OpenSearchResponseParser {
       return { [key]: { type: value.type } };
     });
   };
+
+  private transformAggregationsResult = <T extends string>(
+    aggregations: AggregationsResponseSchemaType['aggregations'],
+    osResponseKey: keyof AggregationsResponseSchemaType['aggregations'],
+    outputKey: T,
+  ) =>
+    aggregations[osResponseKey].buckets.map(element => ({
+      [outputKey]: element.key,
+      count: element.doc_count,
+    }));
 }

--- a/backend/adapters/openSearch/openSearchResponseSchemas.ts
+++ b/backend/adapters/openSearch/openSearchResponseSchemas.ts
@@ -34,5 +34,18 @@ export const AggregationsResponseSchema = z.object({
     file_types: z.object({
       buckets: z.array(BucketElementSchema),
     }),
+    systems: z.object({
+      buckets: z.array(BucketElementSchema),
+    }),
+    track_numbers: z.object({
+      buckets: z.array(BucketElementSchema),
+    }),
+    track_parts: z.object({
+      buckets: z.array(BucketElementSchema),
+    }),
   }),
 });
+
+export type AggregationsResponseSchemaType = z.infer<
+  typeof AggregationsResponseSchema
+>;

--- a/backend/types/portDataStorage.ts
+++ b/backend/types/portDataStorage.ts
@@ -7,5 +7,8 @@ export interface IMetadataStorageInterface {
   getMetadataAggregations: () => Promise<{
     reportTypes: Array<{ reportType: string; count: number }>;
     fileTypes: Array<{ fileType: string; count: number }>;
+    system: Array<{ fileType: string; count: number }>;
+    trackNumber: Array<{ fileType: string; count: number }>;
+    trackPart: Array<{ fileType: string; count: number }>;
   }>;
 }

--- a/backend/types/portDataStorage.ts
+++ b/backend/types/portDataStorage.ts
@@ -7,8 +7,8 @@ export interface IMetadataStorageInterface {
   getMetadataAggregations: () => Promise<{
     reportTypes: Array<{ reportType: string; count: number }>;
     fileTypes: Array<{ fileType: string; count: number }>;
-    system: Array<{ fileType: string; count: number }>;
-    trackNumber: Array<{ fileType: string; count: number }>;
-    trackPart: Array<{ fileType: string; count: number }>;
+    systems: Array<{ value: string; count: number }>;
+    trackNumbers: Array<{ value: string; count: number }>;
+    trackParts: Array<{ value: string; count: number }>;
   }>;
 }

--- a/backend/types/portFile.ts
+++ b/backend/types/portFile.ts
@@ -1,10 +1,6 @@
-import { S3EventRecord } from "aws-lambda";
-import { IFileResult } from "./types";
+import { S3EventRecord } from 'aws-lambda';
+import { IFileResult } from './index';
 
 export interface IFileInterface {
   getFile: (eventRecord: S3EventRecord) => Promise<IFileResult>;
 }
-
-// export interface IFilePortInterface {
-//   getFile: () => Promise<{ fileBody: string; contentType: string }>;
-// }


### PR DESCRIPTION
Adds three new new fields to meta endpoint response: 
- systems
- trackNumbers
- trackParts

This pull request in current form is non-breaking but leaves improvement to response structure. The three below small breaking modifications would make the endpoint cleaner:

- Added new fields list return a list of values in generic format {value: "some_value", count:2 } where as already existing aggregations (reportType, fileType) instead of value a specific field name is used  {reportType: "some_value", count:2 }. It would be better to return all in format {value: "some_value", count:2 }
- fields property structure is cumbersome [{campaign:{type:text}] and could be replaced with simpler [{value: campaign, type:text}]
- filter options data would be best nested under some common property such as filterOptions leaving top level structure cleaner {fields: Array<something>, filterOptions: Record<string, something>}