### PR TITLE
fix: RAITA-8 collection of updates and fixes

### DIFF
--- a/backend/adapters/s3FileRepository.ts
+++ b/backend/adapters/s3FileRepository.ts
@@ -1,6 +1,5 @@
 import { S3EventRecord } from 'aws-lambda';
 import { S3 } from 'aws-sdk';
-import { string } from 'zod';
 import { IFileResult } from '../types';
 import { IFileInterface } from '../types/portFile';
 

--- a/backend/adapters/s3FileRepository.ts
+++ b/backend/adapters/s3FileRepository.ts
@@ -1,5 +1,6 @@
 import { S3EventRecord } from 'aws-lambda';
 import { S3 } from 'aws-sdk';
+import { string } from 'zod';
 import { IFileResult } from '../types';
 import { IFileInterface } from '../types/portFile';
 
@@ -15,15 +16,27 @@ export class S3FileRepository implements IFileInterface {
     const key = decodeURIComponent(
       eventRecord.s3.object.key.replace(/\+/g, ' '),
     );
-    const file = await this.#s3
+    const filePromise = this.#s3
       .getObject({
         Bucket: bucket,
         Key: key,
       })
       .promise();
+    const tagsPromise = this.#s3
+      .getObjectTagging({
+        Bucket: bucket,
+        Key: key,
+      })
+      .promise();
+    const [file, tagSet] = await Promise.all([filePromise, tagsPromise]);
+    const tags = tagSet.TagSet.reduce((acc, cur) => {
+      acc[cur.Key] = cur.Value;
+      return acc;
+    }, {} as Record<string, string>);
     return {
       fileBody: file.Body?.toString(),
       contentType: file.ContentType,
+      tags,
     };
   };
 }

--- a/backend/containers/zipHandler/package-lock.json
+++ b/backend/containers/zipHandler/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.212.0",
         "@aws-sdk/lib-storage": "^3.216.0",
         "mime-types": "^2.1.35",
+        "pino": "^8.7.0",
         "yauzl": "^2.10.0"
       },
       "devDependencies": {
@@ -1469,6 +1470,25 @@
         "@types/node": "*"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1510,12 +1530,28 @@
         "node": "*"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -1584,10 +1620,105 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+    },
+    "node_modules/pino": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
+      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
@@ -1600,6 +1731,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1620,6 +1759,30 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -1642,6 +1805,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "node_modules/thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.4.1",
@@ -2900,6 +3071,19 @@
         "@types/node": "*"
       }
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2924,10 +3108,20 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
+    "fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
     },
     "fast-xml-parser": {
       "version": "4.0.11",
@@ -2968,10 +3162,84 @@
         "mime-db": "1.52.0"
       }
     },
+    "on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+    },
+    "pino": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
+      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "readable-stream": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    },
+    "process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -2983,10 +3251,33 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA=="
+    },
+    "sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "stream-browserify": {
       "version": "3.0.0",
@@ -3009,6 +3300,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "requires": {
+        "real-require": "^0.2.0"
+      }
     },
     "tslib": {
       "version": "2.4.1",

--- a/backend/containers/zipHandler/package.json
+++ b/backend/containers/zipHandler/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-s3": "^3.212.0",
     "@aws-sdk/lib-storage": "^3.216.0",
     "mime-types": "^2.1.35",
+    "pino": "^8.7.0",
     "yauzl": "^2.10.0"
   },
   "devDependencies": {

--- a/backend/containers/zipHandler/src/constants.ts
+++ b/backend/containers/zipHandler/src/constants.ts
@@ -2,6 +2,13 @@
  * Constants below are duplicates from the main code base
  */
 export const ZIP_SUFFIX = 'zip';
+export const AVI_SUFFIX = 'avi';
+
+// In mermec data TVSS videos are nested in the folders listed in RAITA_DATA_VIDEO_FOLDERS
+// Note: To make configuration more dynamic, SSM Parameter Store could be used to store the values
+export const RAITA_DATA_VIDEO_FOLDERS = ['DriversView'];
+export const RAITA_DATA_VIDEO_SUFFIXES = [AVI_SUFFIX];
+
 export type RaitaSourceSystem =
   typeof raitaSourceSystems[keyof typeof raitaSourceSystems];
 export const raitaSourceSystems = {

--- a/backend/containers/zipHandler/src/index.ts
+++ b/backend/containers/zipHandler/src/index.ts
@@ -5,7 +5,7 @@ import { getConfig } from './config';
 import { processZipFile } from './processZipFile';
 import {
   decodeS3EventPropertyString,
-  getKeyConstituents,
+  getKeyData,
   logMessages,
   RaitaZipError,
 } from './utils';
@@ -23,7 +23,7 @@ async function start() {
   try {
     const zipKey = decodeS3EventPropertyString(key);
     const { path, keyWithoutSuffix, fileSuffix, fileBaseName } =
-      getKeyConstituents(zipKey);
+      getKeyData(zipKey);
     if (fileSuffix !== ZIP_SUFFIX) {
       throw new RaitaZipError('incorrectSuffix');
     }

--- a/backend/containers/zipHandler/src/index.ts
+++ b/backend/containers/zipHandler/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from './utils';
 import { isZipPath, ZipFileData } from './types';
 import { ZIP_SUFFIX } from './constants';
+import { log } from './logger';
 
 start();
 
@@ -18,7 +19,7 @@ async function start() {
   const { bucket, key, targetBucket } = getConfig();
   const startMessage = `Zip extraction from bucket: ${bucket} to ${targetBucket} started for ${key}`;
   // TODO: Temporary logging
-  console.log(startMessage);
+  log.debug(startMessage);
   try {
     const zipKey = decodeS3EventPropertyString(key);
     const { path, keyWithoutSuffix, fileSuffix, fileBaseName } =
@@ -68,11 +69,11 @@ async function start() {
         .then(data => {
           const { entries, streamError } = data;
           // TODO: Temporary logging
-          console.log(logMessages['resultMessage'](entries));
+          log.debug(logMessages['resultMessage'](entries));
           if (streamError) {
             // The process succeeded possibly partially. Currently only logs error, does not throw.
             // TODO: Temporary logging
-            console.log(logMessages['streamErrorMessage'](streamError));
+            log.error(logMessages['streamErrorMessage'](streamError));
           }
         })
         .catch(err => {
@@ -83,7 +84,7 @@ async function start() {
     readStream.pipe(writeStream);
   } catch (err) {
     // TODO: Temporary logging
-    console.log(err);
+    log.error(err);
     // TODO: Possible recovery actions apart from logging
   }
 }

--- a/backend/containers/zipHandler/src/index.ts
+++ b/backend/containers/zipHandler/src/index.ts
@@ -21,7 +21,7 @@ async function start() {
   console.log(startMessage);
   try {
     const zipKey = decodeS3EventPropertyString(key);
-    const { path, fileSuffix } = getKeyConstituents(zipKey);
+    const { path, keyWithoutSuffix, fileSuffix } = getKeyConstituents(zipKey);
     if (fileSuffix !== ZIP_SUFFIX) {
       throw new RaitaZipError('incorrectSuffix');
     }
@@ -29,7 +29,6 @@ async function start() {
     if (!isZipPath(path)) {
       throw new RaitaZipError('incorrectPath');
     }
-    const [system, _year, campaign] = path;
     const s3 = new S3({});
     const getObjectResult = await s3.getObject({
       Bucket: bucket,
@@ -46,7 +45,7 @@ async function start() {
         filePath: ZIP_FILE_PATH,
         targetBucket,
         s3,
-        path,
+        s3KeyPrefix: keyWithoutSuffix,
       })
         .then(data => {
           const { entries, streamError } = data;

--- a/backend/containers/zipHandler/src/logger.ts
+++ b/backend/containers/zipHandler/src/logger.ts
@@ -1,0 +1,39 @@
+import pino from 'pino';
+
+const level = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info';
+
+const XRAY_ENV_NAME = '_X_AMZN_TRACE_ID';
+const TRACE_ID_REGEX = /^Root=(.+);Parent=(.+);/;
+export const getCorrelationId = () => {
+  const tracingInfo = process.env[XRAY_ENV_NAME] || '';
+  const matches = tracingInfo.match(TRACE_ID_REGEX) || ['', '', ''];
+  const correlationId = matches[1];
+  if (correlationId) {
+    return correlationId;
+  }
+};
+
+function getLogger(tag: string) {
+  return pino({
+    level,
+    // Remove unused default fields
+    base: undefined,
+    mixin: () => {
+      return {
+        correlationId: getCorrelationId(),
+        tag,
+      };
+    },
+    // Log level as text instead of number
+    formatters: {
+      level(label: string) {
+        return { level: label };
+      },
+    },
+    // Unix time to ISO time
+    timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`,
+  });
+}
+
+export const log = getLogger('RAITA_BACKEND');
+export const logParsingException = getLogger('RAITA_PARSING_EXCEPTION');

--- a/backend/containers/zipHandler/src/logger.ts
+++ b/backend/containers/zipHandler/src/logger.ts
@@ -1,5 +1,8 @@
 import pino from 'pino';
 
+// Logger implementation here is a duplicate of the logger in main code base
+// Update both implementations if changes are needed.
+
 const level = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info';
 
 const XRAY_ENV_NAME = '_X_AMZN_TRACE_ID';

--- a/backend/containers/zipHandler/src/processZipFile.ts
+++ b/backend/containers/zipHandler/src/processZipFile.ts
@@ -1,7 +1,7 @@
 import * as yauzl from 'yauzl';
 import { S3 } from '@aws-sdk/client-s3';
 import { resolveEntries, uploadToS3 } from './utils';
-import { EntryRecord, ExtractEntriesResult, ZipPath } from './types';
+import { EntryRecord, ExtractEntriesResult } from './types';
 
 /**
  * If there is a possibility that even single file has been succesfully uploaded
@@ -12,12 +12,12 @@ export const processZipFile = ({
   filePath,
   targetBucket,
   s3,
-  path,
+  s3KeyPrefix,
 }: {
   filePath: string;
   targetBucket: string;
   s3: S3;
-  path: ZipPath;
+  s3KeyPrefix: string;
 }) =>
   new Promise<ExtractEntriesResult>((resolve, reject) => {
     // The promise is resolved by calling the
@@ -53,11 +53,9 @@ export const processZipFile = ({
           zipfile.readEntry();
         } else {
           // Entry is a file
-          // Generate key by joining the path of the zip file to the path of the file inside zip
+          // Generate key by joining the prefix to the path of the file inside zip
           // Key determines the path where file is stored in target bucket
-          const key = `${path
-            .slice(0, -1)
-            .join('/')}/${entry.fileName.toString()}`;
+          const key = `${s3KeyPrefix}/${entry.fileName.toString()}`;
           zipfile.openReadStream(entry, (err, readStream) => {
             // Returns a promise for entry which resolves when file is uploaded to S3 (or upload fails)
             const entryResult = new Promise<EntryRecord>(resolveEntry => {

--- a/backend/containers/zipHandler/src/processZipFile.ts
+++ b/backend/containers/zipHandler/src/processZipFile.ts
@@ -1,7 +1,7 @@
 import * as yauzl from 'yauzl';
 import { S3 } from '@aws-sdk/client-s3';
 import { isRaitaVideoFile, resolveEntries, uploadToS3 } from './utils';
-import { EntryRecord, ExtractEntriesResult } from './types';
+import { EntryRecord, ExtractEntriesResult, ZipFileData } from './types';
 
 /**
  * If there is a possibility that even single file has been succesfully uploaded
@@ -13,11 +13,13 @@ export const processZipFile = ({
   targetBucket,
   s3,
   s3KeyPrefix,
+  zipFileData,
 }: {
   filePath: string;
   targetBucket: string;
   s3: S3;
   s3KeyPrefix: string;
+  zipFileData: ZipFileData;
 }) =>
   new Promise<ExtractEntriesResult>((resolve, reject) => {
     // The promise is resolved by calling the
@@ -78,6 +80,7 @@ export const processZipFile = ({
                   targetBucket,
                   key,
                   s3,
+                  zipFileData,
                 });
                 readStream.pipe(writeStream);
                 uploadPromise

--- a/backend/containers/zipHandler/src/processZipFile.ts
+++ b/backend/containers/zipHandler/src/processZipFile.ts
@@ -92,8 +92,9 @@ export const processZipFile = ({
                     // Upload failed, resolve with error
                     resolveEntry({
                       ...entry,
-                      status: 'failure',
-                      failureCause: `Upload to S3 failed: ${
+                      fileName: entry.fileName.toString(),
+                      status: 'error',
+                      errorDescription: `Upload to S3 failed: ${
                         err instanceof Error ? err.message : err
                       }`,
                     });

--- a/backend/containers/zipHandler/src/types.ts
+++ b/backend/containers/zipHandler/src/types.ts
@@ -13,6 +13,12 @@ export type ZipPath = [
   fileName: string,
 ];
 
+export interface ZipFileData {
+  timeStamp: string;
+  timeStampType: string;
+  fileName: string;
+}
+
 export function isZipPath(arg: Array<string>): arg is ZipPath {
   const [system] = arg;
   return arg.length === 5 && !!system && isRaitaSourceSystem(system);

--- a/backend/containers/zipHandler/src/types.ts
+++ b/backend/containers/zipHandler/src/types.ts
@@ -27,8 +27,9 @@ export function isZipPath(arg: Array<string>): arg is ZipPath {
 // END duplicates
 
 export interface EntryRecord {
-  status: 'success' | 'failure';
-  failureDescription: string;
+  fileName: string;
+  status: 'success' | 'error';
+  errorDescription: string;
   compressedSize: number;
   uncompressedSize: number;
 }
@@ -36,7 +37,7 @@ export interface EntryRecord {
 export interface ExtractEntriesResult {
   entries: {
     success: Array<EntryRecord>;
-    failure: Array<EntryRecord>;
+    error: Array<EntryRecord>;
   };
   streamError?: Error;
 }

--- a/backend/containers/zipHandler/src/utils.ts
+++ b/backend/containers/zipHandler/src/utils.ts
@@ -10,7 +10,8 @@ export const getKeyConstituents = (key: string) => {
   const path = key.split('/');
   const fileName = path[path.length - 1];
   const [fileBaseName, fileSuffix] = fileName.split('.');
-  return { path, fileName, fileBaseName, fileSuffix };
+  const [keyWithoutSuffix] = key.split('.');
+  return { path, fileName, fileBaseName, fileSuffix, keyWithoutSuffix };
 };
 
 export const decodeS3EventPropertyString = (s: string) => s.replace(/\+/g, ' ');

--- a/backend/containers/zipHandler/src/utils.ts
+++ b/backend/containers/zipHandler/src/utils.ts
@@ -30,7 +30,9 @@ export const getKeyData = (key: string) => {
     lastDotInFileName >= 0 && fileName.length - 1 > lastDotInFileName
       ? fileName.slice(lastDotInFileName + 1)
       : '';
-  const keyWithoutSuffix = key.slice(0, -fileSuffix.length);
+  const keyWithoutSuffix = fileSuffix
+    ? key.slice(0, -(fileSuffix.length + 1))
+    : key;
   return {
     path,
     rootFolder,

--- a/backend/containers/zipHandler/src/utils.ts
+++ b/backend/containers/zipHandler/src/utils.ts
@@ -37,7 +37,7 @@ export const resolveEntries = async (entries: Array<Promise<EntryRecord>>) => {
       acc[cur.status].push(cur);
       return acc;
     },
-    { success: [], failure: [] } as ExtractEntriesResult['entries'],
+    { success: [], error: [] } as ExtractEntriesResult['entries'],
   );
 };
 
@@ -64,7 +64,7 @@ export const uploadToS3 = ({
       Key: key,
       Body: passThrough,
       ContentType: mime.lookup(fileName) || undefined,
-      Tagging: `ZipTimeStamp=${zipFileData.timeStamp},ZipTimeStampType=${zipFileData.timeStampType},ZipFileName=${zipFileData.fileName}`,
+      Tagging: `ZipTimeStamp=${zipFileData.timeStamp}&ZipTimeStampType=${zipFileData.timeStampType}&ZipFileName=${zipFileData.fileName}`,
     },
   });
   return {
@@ -89,11 +89,13 @@ export const isRaitaVideoFile = (fileName: string) => {
 
 export const logMessages = {
   resultMessage: (entries: ExtractEntriesResult['entries']) =>
-    `${entries.success.length} files succesfully extracted from zip, ${
-      entries.failure.length
-    } files failed in the process. Total compressed size of extracted files ${compressedSize(
+    `${
+      entries.success.length
+    } files succesfully extracted from zip. Total compressed size of extracted files ${compressedSize(
       entries,
-    )}.`,
+    )}. ${entries.error.length} files failed in the process ${entries.error
+      .map(entry => `${entry.fileName}: ${entry.errorDescription}`)
+      .join(', ')} `,
   streamErrorMessage: (streamError: unknown) =>
     `ERROR: Zip extraction did not succeed until end, extraction failed due to zip error: ${streamError}`,
 };

--- a/backend/containers/zipHandler/src/utils.ts
+++ b/backend/containers/zipHandler/src/utils.ts
@@ -3,7 +3,12 @@ import { Upload } from '@aws-sdk/lib-storage';
 import { PassThrough } from 'stream';
 import mime from 'mime-types';
 import { EntryRecord, ExtractEntriesResult } from './types';
-import { RaitaSourceSystem, raitaSourceSystems } from './constants';
+import {
+  RAITA_DATA_VIDEO_FOLDERS,
+  RAITA_DATA_VIDEO_SUFFIXES,
+  RaitaSourceSystem,
+  raitaSourceSystems,
+} from './constants';
 
 // Duplicates BEGIN: Functions duplicating logic from main code base
 export const getKeyConstituents = (key: string) => {
@@ -68,6 +73,17 @@ export const uploadToS3 = ({
 const compressedSize = (entries: ExtractEntriesResult['entries']) =>
   entries.success.reduce((acc, cur) => acc + cur.compressedSize, 0);
 
+/**
+ * Return true is the file is detected as video file
+ */
+export const isRaitaVideoFile = (fileName: string) => {
+  const { path, fileSuffix } = getKeyConstituents(fileName);
+  return (
+    RAITA_DATA_VIDEO_SUFFIXES.some(suffix => suffix === fileSuffix) ||
+    RAITA_DATA_VIDEO_FOLDERS.some(folder => path.includes(folder))
+  );
+};
+
 export const logMessages = {
   resultMessage: (entries: ExtractEntriesResult['entries']) =>
     `${entries.success.length} files succesfully extracted from zip, ${
@@ -93,7 +109,3 @@ export class RaitaZipError extends Error {
     super(message);
   }
 }
-
-/**
- * Functions below are duplicates from the main code base
- */

--- a/backend/containers/zipHandler/src/utils.ts
+++ b/backend/containers/zipHandler/src/utils.ts
@@ -2,7 +2,7 @@ import { S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { PassThrough } from 'stream';
 import mime from 'mime-types';
-import { EntryRecord, ExtractEntriesResult } from './types';
+import { EntryRecord, ExtractEntriesResult, ZipFileData } from './types';
 import {
   RAITA_DATA_VIDEO_FOLDERS,
   RAITA_DATA_VIDEO_SUFFIXES,
@@ -48,10 +48,12 @@ export const uploadToS3 = ({
   targetBucket,
   key,
   s3,
+  zipFileData,
 }: {
   targetBucket: string;
   key: string;
   s3: S3;
+  zipFileData: ZipFileData;
 }) => {
   const { fileName } = getKeyConstituents(key);
   const passThrough = new PassThrough();
@@ -62,6 +64,7 @@ export const uploadToS3 = ({
       Key: key,
       Body: passThrough,
       ContentType: mime.lookup(fileName) || undefined,
+      Tagging: `ZipTimeStamp=${zipFileData.timeStamp},ZipTimeStampType=${zipFileData.timeStampType},ZipFileName=${zipFileData.fileName}`,
     },
   });
   return {

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/contentDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/contentDataParser.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import {
   IColonSeparatedKeyValuePairDefinition,
   IExtractionSpec,
@@ -7,17 +8,11 @@ import { parsePrimitive } from './parsePrimitives';
 import { regexCapturePatterns } from './regex';
 import { fileSuffixesToIncudeInMetadataParsing } from '../../../../constants';
 import { RaitaParseError } from '../../utils';
-import { createHash } from 'crypto';
 /**
  * Resolves whether content data parsing is needed for the file
  */
-export const shouldParseContent = ({ fileName }: { fileName: string }) => {
-  const suffix = fileName.substring(
-    fileName.lastIndexOf('.') + 1,
-    fileName.length,
-  );
-  return suffix === fileSuffixesToIncudeInMetadataParsing.TXT_FILE;
-};
+export const shouldParseContent = (suffix: string) =>
+  suffix === fileSuffixesToIncudeInMetadataParsing.TXT_FILE;
 
 /**
  * Resolves whether hash should be calculated for the file contents

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
@@ -1,14 +1,69 @@
-import { IExtractionSpec, ParseValueResult } from '../../../types';
+import { EMPTY_FILE_INDICATOR } from '../../../../constants';
+import {
+  IExtractionSpec,
+  IExtractionSpecLabels,
+  ParseValueResult,
+} from '../../../types';
 import { logger } from '../../../utils/logger';
-import { RaitaParseError } from '../../utils';
+import { isExcelSuffix, isKnownSuffix, RaitaParseError } from '../../utils';
 import { parsePrimitive } from './parsePrimitives';
 
-// TODO: Remove this typeguard by improving types
-function suffixIsKnown(arg: string): arg is 'csv' | 'txt' | 'pdf' {
-  return ['pdf', 'txt', 'csv'].includes(arg);
-}
+const parseFileNameParts = (
+  labels: IExtractionSpecLabels,
+  fileBaseNameParts: Array<string>,
+) =>
+  fileBaseNameParts.reduce<ParseValueResult>((acc, cur, index) => {
+    // Handle the empty file indicator as special case.
+    // Implementation depends on this incicator being in the end of the string.
+    if (cur === EMPTY_FILE_INDICATOR) {
+      acc['isEmpty'] = true;
+      return acc;
+    }
+    // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
+    const { name, parseAs } = labels[index + 1];
+    if (name) {
+      const { key, value } = parseAs
+        ? parsePrimitive(name, cur, parseAs)
+        : { key: name, value: cur };
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
 
-const EMPTY_FILE_INDICATOR = 'EMPTY';
+const validateGenericFileNameStructureOrFail = (
+  fileName: string,
+  labels: IExtractionSpecLabels,
+  fileBaseNameParts: Array<string>,
+) => {
+  const lastFileBaseNamePart = fileBaseNameParts[fileBaseNameParts.length - 1];
+  const labelCount = Object.keys(labels).length;
+  // The file name may have empty file indicator in the end, increasing expected
+  // part count by one
+  const expectedFileNamePartCount =
+    lastFileBaseNamePart === EMPTY_FILE_INDICATOR ? labelCount + 1 : labelCount;
+  if (fileBaseNameParts.length !== expectedFileNamePartCount) {
+    throw new RaitaParseError(
+      `Unexpected number of file name segments in ${fileName}. Expected ${expectedFileNamePartCount}, received ${fileBaseNameParts.length}.`,
+    );
+  }
+};
+
+const parseExcelFileNameData = (
+  labels: IExtractionSpecLabels,
+  fileBaseNameParts: Array<string>,
+) => {
+  // Only process two first segments of file name, ignore others
+  return parseFileNameParts(labels, fileBaseNameParts.slice(0, 2));
+};
+
+const parseGenericFileNameData = (
+  fileName: string,
+  labels: IExtractionSpecLabels,
+  fileBaseNameParts: Array<string>,
+) => {
+  validateGenericFileNameStructureOrFail(fileName, labels, fileBaseNameParts);
+  return parseFileNameParts(labels, fileBaseNameParts);
+};
 
 export const extractFileNameData = (
   fileName: string,
@@ -20,45 +75,17 @@ export const extractFileNameData = (
       throw new RaitaParseError(`Unexpected file name structure: ${fileName}`);
     }
     const [baseName, suffix] = fileNameParts;
-    if (!suffixIsKnown(suffix)) {
+    if (!isKnownSuffix(suffix)) {
       throw new RaitaParseError(`Unexpected suffix in file name: ${fileName}`);
     }
-    const labels = fileNamePartLabels[suffix];
+    // File name segments are separated by underscore
     const fileBaseNameParts = baseName.split('_');
-    const lastFileBaseNamePart =
-      fileBaseNameParts[fileBaseNameParts.length - 1];
-    const labelCount = Object.keys(labels).length;
-    // The file name may have empty file indicator in the end, increasing expected
-    // part count by one
-    const expectedFileNamePartCount =
-      lastFileBaseNamePart === EMPTY_FILE_INDICATOR
-        ? labelCount + 1
-        : labelCount;
-    if (fileBaseNameParts.length !== expectedFileNamePartCount) {
-      throw new RaitaParseError(
-        `Unexpected number of file name segments in ${fileName}. Expected ${expectedFileNamePartCount}, received ${fileBaseNameParts.length}.`,
-      );
-    }
-    const specBasedMetadata = fileBaseNameParts.reduce<ParseValueResult>(
-      (acc, cur, index) => {
-        // Handle the empty file indicator as special case.
-        // Implementation depends on this incicator being in the end of the string.
-        if (cur === EMPTY_FILE_INDICATOR) {
-          acc['isEmpty'] = true;
-          return acc;
-        }
-        // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
-        const { name, parseAs } = labels[index + 1];
-        if (name) {
-          const { key, value } = parseAs
-            ? parsePrimitive(name, cur, parseAs)
-            : { key: name, value: cur };
-          acc[key] = value;
-        }
-        return acc;
-      },
-      {},
-    );
+    // Get labels based on the file suffix from extractionSpec
+    const labels = fileNamePartLabels[suffix];
+    // Excel file name parsing is special case, some name segments need to be ignored
+    const specBasedMetadata = isExcelSuffix(suffix)
+      ? parseExcelFileNameData(labels, fileBaseNameParts)
+      : parseGenericFileNameData(fileName, labels, fileBaseNameParts);
     return {
       file_type: suffix,
       ...specBasedMetadata,

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
@@ -5,7 +5,7 @@ import {
   ParseValueResult,
 } from '../../../types';
 import { logger } from '../../../utils/logger';
-import { isExcelSuffix, isKnownSuffix, RaitaParseError } from '../../utils';
+import { isExcelSuffix, isKnownSuffix, KeyData, RaitaParseError } from '../../utils';
 import { parsePrimitive } from './parsePrimitives';
 
 const parseFileNameParts = (
@@ -66,28 +66,27 @@ const parseGenericFileNameData = (
 };
 
 export const extractFileNameData = (
-  fileName: string,
+  keyData: KeyData,
   fileNamePartLabels: IExtractionSpec['fileNameExtractionSpec'],
 ) => {
   try {
-    const fileNameParts = fileName.split('.');
-    if (fileNameParts.length !== 2) {
+    const {fileName, fileBaseName, fileSuffix} = keyData
+    if (!fileBaseName || !fileSuffix) {
       throw new RaitaParseError(`Unexpected file name structure: ${fileName}`);
     }
-    const [baseName, suffix] = fileNameParts;
-    if (!isKnownSuffix(suffix)) {
+    if (!isKnownSuffix(fileSuffix)) {
       throw new RaitaParseError(`Unexpected suffix in file name: ${fileName}`);
     }
     // File name segments are separated by underscore
-    const fileBaseNameParts = baseName.split('_');
+    const fileBaseNameParts = fileBaseName.split('_');
     // Get labels based on the file suffix from extractionSpec
-    const labels = fileNamePartLabels[suffix];
+    const labels = fileNamePartLabels[fileSuffix];
     // Excel file name parsing is special case, some name segments need to be ignored
-    const specBasedMetadata = isExcelSuffix(suffix)
+    const specBasedMetadata = isExcelSuffix(fileSuffix)
       ? parseExcelFileNameData(labels, fileBaseNameParts)
       : parseGenericFileNameData(fileName, labels, fileBaseNameParts);
     return {
-      file_type: suffix,
+      file_type: fileSuffix,
       ...specBasedMetadata,
     };
   } catch (error) {

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
@@ -63,9 +63,6 @@ export async function handleInspectionFileEvent(event: S3Event): Promise<void> {
           );
           return null;
         }
-
-        // TODO: Handle tag creation based on root folder
-
         const fileName = decodeUriString(path[path.length - 1]);
         const parseResults = await parseFileMetadata({
           fileName,
@@ -80,6 +77,7 @@ export async function handleInspectionFileEvent(event: S3Event): Promise<void> {
           bucket_name: eventRecord.s3.bucket.name,
           size: eventRecord.s3.object.size,
           ...parseResults,
+          tags: file.tags,
         };
       },
     );

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/pathDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/pathDataParser.ts
@@ -1,18 +1,27 @@
 import { IExtractionSpec, ParseValueResult } from '../../../types';
 import { logger } from '../../../utils/logger';
+import { isExcelSuffix, KeyData } from '../../utils';
 import { parsePrimitive } from './parsePrimitives';
 
 /**
  * Extract meta data from the file path
  */
 export const extractPathData = (
-  path: Array<string>,
+  keyData: KeyData,
   folderLabels: IExtractionSpec['folderTreeExtractionSpec'],
 ) => {
-  const expectedPathLength = Object.keys(folderLabels).length;
+  const { path, fileSuffix } = keyData;
+  // Excel files are located higher in the hierarchy than other files which always are at the lowest level,
+  // as quick and dirty solution expectedPathLength for excel files is hard coded to 5 which corresponds to their location.
+  // This is a rough implementation which can be replaced with more sofisticated one as the needs for
+  // path data parsing come more clear (is is enough to configure this based on file suffix or if more detailed configration is needed),
+  // more robust solution should be built on modifying the structure in extractionSpec parsing instructions
+  const expectedPathLength = isExcelSuffix(fileSuffix)
+    ? 5
+    : Object.keys(folderLabels).length;
   if (path.length !== expectedPathLength) {
     logger.logParsingException(
-      `Unexpected folder path length for path ${path}. Folder path analysis not carried out`,
+      `Unexpected folder path length ${path.length} for path ${path}, expected ${expectedPathLength}. Folder path analysis not carried out`,
     );
     return {};
   }

--- a/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
@@ -4,7 +4,7 @@ import { logger } from '../../../utils/logger';
 import { getGetEnvWithPreassignedContext } from '../../../../utils';
 import {
   decodeS3EventPropertyString,
-  getKeyConstituents,
+  getKeyData,
   isZipPath,
   RaitaLambdaError,
 } from '../../utils';
@@ -28,7 +28,7 @@ export async function handleReceptionFileEvent(event: S3Event): Promise<void> {
       const config = getLambdaConfigOrFail();
       const bucket = eventRecord.s3.bucket;
       const key = decodeS3EventPropertyString(eventRecord.s3.object.key);
-      const { path, fileSuffix } = getKeyConstituents(key);
+      const { path, fileSuffix } = getKeyData(key);
       if (!isZipPath(path)) {
         throw new RaitaLambdaError(`Unexpected file path ${path}`, 400);
       }

--- a/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
@@ -43,8 +43,8 @@ export async function handleReceptionFileEvent(event: S3Event): Promise<void> {
         // Copy the file to target S3 bucket if not zip file
         const command = new CopyObjectCommand({
           Key: key,
-          Bucket: bucket.name,
-          CopySource: key,
+          Bucket: config.targetBucketName,
+          CopySource: `${bucket.name}/${key}`,
         });
         const s3Client = new S3Client({});
         return s3Client.send(command);

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -88,7 +88,9 @@ export const getKeyData = (key: string) => {
     lastDotInFileName >= 0 && fileName.length - 1 > lastDotInFileName
       ? fileName.slice(lastDotInFileName + 1)
       : '';
-  const keyWithoutSuffix = key.slice(0, -fileSuffix.length);
+  const keyWithoutSuffix = fileSuffix
+    ? key.slice(0, -(fileSuffix.length + 1))
+    : key;
   return {
     path,
     rootFolder,

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -1,4 +1,9 @@
 import {
+  ExcelSuffix,
+  fileSuffixesToIncudeInMetadataParsing,
+  KnownSuffix,
+} from '../../constants';
+import {
   getGetEnvWithPreassignedContext,
   isRaitaSourceSystem,
 } from '../../utils';
@@ -89,7 +94,22 @@ export type ZipPath = [
   fileName: string,
 ];
 
+// Type guards
+
 export function isZipPath(arg: Array<string>): arg is ZipPath {
   const [system] = arg;
   return arg.length === 5 && !!system && isRaitaSourceSystem(system);
+}
+
+export function isKnownSuffix(arg: string): arg is KnownSuffix {
+  return Object.keys(fileSuffixesToIncudeInMetadataParsing).some(
+    suffix => suffix === arg,
+  );
+}
+
+export function isExcelSuffix(arg: string): arg is ExcelSuffix {
+  return (
+    fileSuffixesToIncudeInMetadataParsing.XLSX_FILE === arg ||
+    fileSuffixesToIncudeInMetadataParsing.XLS_FILE === arg
+  );
 }

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -102,7 +102,7 @@ export function isZipPath(arg: Array<string>): arg is ZipPath {
 }
 
 export function isKnownSuffix(arg: string): arg is KnownSuffix {
-  return Object.keys(fileSuffixesToIncudeInMetadataParsing).some(
+  return Object.values(fileSuffixesToIncudeInMetadataParsing).some(
     suffix => suffix === arg,
   );
 }

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -76,16 +76,27 @@ export const getOpenSearchLambdaConfigOrFail = () => {
 
 export const decodeS3EventPropertyString = (s: string) => s.replace(/\+/g, ' ');
 
-
-export type KeyData = ReturnType<typeof getKeyData>
+export type KeyData = ReturnType<typeof getKeyData>;
 export const getKeyData = (key: string) => {
   const path = key.split('/');
   const rootFolder = path[0];
   const fileName = decodeUriString(path[path.length - 1]);
-  const lastDot = fileName.lastIndexOf('.');
-  const fileBaseName = fileName.slice(0, lastDot);
-  const fileSuffix = lastDot >= 0 && fileName.length - 1 > lastDot ? fileName.slice(lastDot + 1): '';
-  return { path, rootFolder, fileName, fileBaseName, fileSuffix };
+  const lastDotInFileName = fileName.lastIndexOf('.');
+  const fileBaseName =
+    lastDotInFileName >= 0 ? fileName.slice(0, lastDotInFileName) : fileName;
+  const fileSuffix =
+    lastDotInFileName >= 0 && fileName.length - 1 > lastDotInFileName
+      ? fileName.slice(lastDotInFileName + 1)
+      : '';
+  const keyWithoutSuffix = key.slice(0, -fileSuffix.length);
+  return {
+    path,
+    rootFolder,
+    fileName,
+    fileBaseName,
+    fileSuffix,
+    keyWithoutSuffix,
+  };
 };
 
 // Expected structure for zip file path parts is designated in the PathType type

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -76,11 +76,16 @@ export const getOpenSearchLambdaConfigOrFail = () => {
 
 export const decodeS3EventPropertyString = (s: string) => s.replace(/\+/g, ' ');
 
-export const getKeyConstituents = (key: string) => {
+
+export type KeyData = ReturnType<typeof getKeyData>
+export const getKeyData = (key: string) => {
   const path = key.split('/');
-  const fileName = path[path.length - 1];
-  const [fileBaseName, fileSuffix] = fileName.split('.');
-  return { path, fileName, fileBaseName, fileSuffix };
+  const rootFolder = path[0];
+  const fileName = decodeUriString(path[path.length - 1]);
+  const lastDot = fileName.lastIndexOf('.');
+  const fileBaseName = fileName.slice(0, lastDot);
+  const fileSuffix = lastDot >= 0 && fileName.length - 1 > lastDot ? fileName.slice(lastDot + 1): '';
+  return { path, rootFolder, fileName, fileBaseName, fileSuffix };
 };
 
 // Expected structure for zip file path parts is designated in the PathType type

--- a/backend/types/index.ts
+++ b/backend/types/index.ts
@@ -18,4 +18,5 @@ export interface FileMetadataEntry {
 export interface IFileResult {
   fileBody: string | undefined;
   contentType: string | undefined;
+  tags: Record<string, string>;
 }

--- a/backend/types/specification.ts
+++ b/backend/types/specification.ts
@@ -26,9 +26,13 @@ export const ExtractionSpec = z.object({
     csv: z.record(z.string(), FieldExtractionSpecObject),
     txt: z.record(z.string(), FieldExtractionSpecObject),
     pdf: z.record(z.string(), FieldExtractionSpecObject),
+    xlsx: z.record(z.string(), FieldExtractionSpecObject),
+    xls: z.record(z.string(), FieldExtractionSpecObject),
   }),
   folderTreeExtractionSpec: z.record(FieldExtractionSpecObject),
   fileContentExtractionSpec: z.array(ColonSeparatedKeyValuePairDefinition),
 });
 
 export type IExtractionSpec = z.infer<typeof ExtractionSpec>;
+export type IExtractionSpecLabels =
+  IExtractionSpec['fileNameExtractionSpec'][keyof IExtractionSpec['fileNameExtractionSpec']];

--- a/backend/utils/logger.ts
+++ b/backend/utils/logger.ts
@@ -1,5 +1,8 @@
 import pino from 'pino';
 
+// Logger implemetation here is duplicated by a copy under backend/containers/zipHandler.
+// Update both implementations if changes are needed.
+
 const level = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info';
 
 const XRAY_ENV_NAME = '_X_AMZN_TRACE_ID';

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,8 +1,20 @@
+export type KnownSuffix =
+  typeof fileSuffixesToIncudeInMetadataParsing[keyof typeof fileSuffixesToIncudeInMetadataParsing];
+
+export type ExcelSuffix =
+  | typeof fileSuffixesToIncudeInMetadataParsing['XLSX_FILE']
+  | typeof fileSuffixesToIncudeInMetadataParsing['XLS_FILE'];
+
 export const fileSuffixesToIncudeInMetadataParsing = {
   TXT_FILE: 'txt',
   PDF_FILE: 'pdf',
   CSV_FILE: 'csv',
+  XLSX_FILE: 'xlsx',
+  XLS_FILE: 'xls',
 } as const;
+
+export const ZIP_SUFFIX = 'zip';
+export const EMPTY_FILE_INDICATOR = 'EMPTY';
 
 export type RaitaSourceSystem =
   typeof raitaSourceSystems[keyof typeof raitaSourceSystems];
@@ -12,8 +24,6 @@ export const raitaSourceSystems = {
   Emma: 'Emma',
   Elli: 'Elli',
 } as const;
-
-export const ZIP_SUFFIX = 'zip';
 
 export const RAITA_PARSING_EXCEPTION = '[RAITA PARSING EXCEPTION]';
 export const SSM_CLOUDFRONT_CERTIFICATE_ARN =

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -110,7 +110,7 @@ export const getRaitaStackConfig = (
   raitaEnv: RaitaEnvironment,
 ) => ({
   parserConfigurationFile: 'extractionSpec.json',
-  openSearchMetadataIndex: 'metadata-index',
+  openSearchMetadataIndex: 'metadata',
   raitaSourceSystems: Object.values(raitaSourceSystems),
   cloudfrontCertificateArn: getSSMParameter(
     scope,


### PR DESCRIPTION
This pull request is a collection of updates and fixes:

- rename os index 'metadata-index' to 'metadata'
- Ignore video-files in zip-extraction
- RAITA-208 Fix copying non zip files from reception bucket to data bucket
- zip-file name addition to extracted file key
- zip name and zip date added into extracted file tags (and additionally to meta data entry)
- fix for excel file name meta data parsing
- zipHandler container to use new logging solution

