### PR TITLE
fix: RAITA-228 sftp partial files

### DIFF
--- a/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
@@ -5,6 +5,7 @@ import { getGetEnvWithPreassignedContext } from '../../../../utils';
 import {
   decodeS3EventPropertyString,
   getKeyData,
+  isExcelSuffix,
   isZipPath,
   RaitaLambdaError,
 } from '../../utils';
@@ -39,8 +40,8 @@ export async function handleReceptionFileEvent(event: S3Event): Promise<void> {
           key,
           sourceBucketName: bucket.name,
         });
-      } else {
-        // Copy the file to target S3 bucket if not zip file
+      } else if (isExcelSuffix(fileSuffix)) {
+        // Copy the file to target S3 bucket if is an Excel file
         const command = new CopyObjectCommand({
           Key: key,
           Bucket: config.targetBucketName,

--- a/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
@@ -41,7 +41,7 @@ export async function handleReceptionFileEvent(event: S3Event): Promise<void> {
           sourceBucketName: bucket.name,
         });
       } else if (isExcelSuffix(fileSuffix)) {
-        // Copy the file to target S3 bucket if is an Excel file
+        // Copy the file to target S3 bucket if it is an Excel file
         const command = new CopyObjectCommand({
           Key: key,
           Bucket: config.targetBucketName,

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -66,20 +66,20 @@ export class DataProcessStack extends NestedStack {
       scope: this,
       name: 'inspection-data',
       raitaEnv,
-      raitaStackIdentifier: raitaStackIdentifier,
+      raitaStackIdentifier,
     });
     const configurationBucket = createRaitaBucket({
       scope: this,
       name: 'parser-configuration',
       raitaEnv,
-      raitaStackIdentifier: raitaStackIdentifier,
+      raitaStackIdentifier,
     });
     const dataReceptionBucket = createRaitaBucket({
       scope: this,
       name: 'data-reception',
       raitaEnv,
       raitaStackIdentifier,
-      eventBridgeEnabled: true,
+      versioned: true,
     });
 
     // Grant sftpUser access to data reception bucket
@@ -302,6 +302,7 @@ export class DataProcessStack extends NestedStack {
         's3:PutObjectAcl',
         's3:ListBucket',
         's3:GetBucketLocation',
+        's3:DeleteObject',
       ],
       resources: [
         dataReceptionBucket.bucketArn,

--- a/lib/raitaResourceCreators.ts
+++ b/lib/raitaResourceCreators.ts
@@ -13,13 +13,13 @@ export const createRaitaBucket = ({
   name,
   raitaEnv,
   raitaStackIdentifier,
-  eventBridgeEnabled,
+  versioned = false,
 }: {
   scope: Construct;
   name: string;
   raitaEnv: RaitaEnvironment;
   raitaStackIdentifier: string;
-  eventBridgeEnabled?: boolean;
+  versioned?: boolean;
 }) => {
   const removalPolicy = getRemovalPolicy(raitaEnv);
   const autoDeleteObjects = removalPolicy === RemovalPolicy.DESTROY;
@@ -27,12 +27,11 @@ export const createRaitaBucket = ({
     bucketName: `s3-${raitaStackIdentifier}-${name}`,
     removalPolicy,
     autoDeleteObjects,
-    versioned: false,
+    versioned,
     accessControl: s3.BucketAccessControl.PRIVATE,
     blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
     encryption: s3.BucketEncryption.S3_MANAGED,
-    eventBridgeEnabled,
   });
 };
 


### PR DESCRIPTION
Pull request fixes problem with sftp partial/temp files in data reception bucket.

- Reception bucket files are versioned
- Delete permission for sftp user
- Only excel files are copied directly to destination data bucket (not all non-zip files). This probably needs to be modified at some later point when more is known (Jira issue exists for doc file).

Jira 232 created for temp file permanent deletion from reception bucket.

Untested, must be tested in main-stack.