### PR TITLE
fix(api): RAITA-224 cleanup files endpoint response

### DIFF
--- a/backend/adapters/openSearch/openSearchRepository.ts
+++ b/backend/adapters/openSearch/openSearchRepository.ts
@@ -44,7 +44,7 @@ export class OpenSearchRepository implements IMetadataStorageInterface {
       index: this.#dataIndex,
       body: query,
     });
-    return response;
+    return this.#responseParser.parseSearchResponse(response);
   };
 
   getMetadataFields = async () => {

--- a/backend/adapters/openSearch/openSearchResponseParser.ts
+++ b/backend/adapters/openSearch/openSearchResponseParser.ts
@@ -2,6 +2,7 @@ import {
   AggregationsResponseSchema,
   AggregationsResponseSchemaType,
   FieldMappingsSchema,
+  MetadataSearchResponseSchema,
 } from './openSearchResponseSchemas';
 
 export class OpenSearchResponseParser {
@@ -58,6 +59,20 @@ export class OpenSearchResponseParser {
     return Object.entries(fields).map(([key, value]) => {
       return { [key]: { type: value.type } };
     });
+  };
+
+  parseSearchResponse = (res: any) => {
+    if (!res.body) {
+      throw new Error('Missing search response body');
+    }
+    const responseData = MetadataSearchResponseSchema.parse(res.body);
+    return {
+      total: responseData.total,
+      hits: responseData.hits.map(hit => {
+        const { _score: score, _source: source, ..._rest } = hit;
+        return { score, source };
+      }),
+    };
   };
 
   private transformAggregationsResult = <T extends string>(

--- a/backend/adapters/openSearch/openSearchResponseSchemas.ts
+++ b/backend/adapters/openSearch/openSearchResponseSchemas.ts
@@ -1,4 +1,9 @@
-import { z } from 'zod';
+import {
+  SearchHit,
+  SearchResponse,
+  SearchTotalHitsRelation,
+} from '@opensearch-project/opensearch/api/types';
+import { number, z } from 'zod';
 
 // NOTE: This is INCOMPLETE schema typing of metadata fields
 const MetadataFieldSchema = z.object({
@@ -50,6 +55,9 @@ export type AggregationsResponseSchemaType = z.infer<
   typeof AggregationsResponseSchema
 >;
 
+/**
+ * Note: Incomplete schema description
+ */
 const MetadataDocument = z.object({
   key: z.string(),
   file_name: z.string(),
@@ -57,23 +65,34 @@ const MetadataDocument = z.object({
   bucket_name: z.string(),
   size: z.number(),
   metadata: z.record(z.string(), z.any()),
+  tags: z.record(z.string(), z.any()),
 });
+
+export type IMetadataDocument = z.infer<typeof MetadataDocument>;
 
 /**
  * Note: Incomplete schema description
  */
-const MetadataSearchResult = z.object({
-  _score: z.number(),
+const PartialSearchHit: z.ZodType<SearchHit<IMetadataDocument>> = z.object({
+  _index: z.string(),
+  _id: z.string(),
   _source: MetadataDocument,
 });
 
 /**
  * Note: Incomplete schema description
  */
-export const MetadataSearchResponseSchema = z.object({
-  hits: z.array(MetadataSearchResult),
-  total: z.object({
-    value: z.number(),
-    relation: z.string(),
+export const MetadataSearchResponseSchema: z.ZodType<
+  Pick<SearchResponse<IMetadataDocument>, 'hits'>
+> = z.object({
+  hits: z.object({
+    hits: z.array(PartialSearchHit),
+    total: z.union([
+      z.number(),
+      z.object({
+        value: z.number(),
+        relation: z.union([z.literal('gte'), z.literal('eq')]),
+      }),
+    ]),
   }),
 });

--- a/backend/adapters/openSearch/openSearchResponseSchemas.ts
+++ b/backend/adapters/openSearch/openSearchResponseSchemas.ts
@@ -49,3 +49,31 @@ export const AggregationsResponseSchema = z.object({
 export type AggregationsResponseSchemaType = z.infer<
   typeof AggregationsResponseSchema
 >;
+
+const MetadataDocument = z.object({
+  key: z.string(),
+  file_name: z.string(),
+  bucket_arn: z.string(),
+  bucket_name: z.string(),
+  size: z.number(),
+  metadata: z.record(z.string(), z.any()),
+});
+
+/**
+ * Note: Incomplete schema description
+ */
+const MetadataSearchResult = z.object({
+  _score: z.number(),
+  _source: MetadataDocument,
+});
+
+/**
+ * Note: Incomplete schema description
+ */
+export const MetadataSearchResponseSchema = z.object({
+  hits: z.array(MetadataSearchResult),
+  total: z.object({
+    value: z.number(),
+    relation: z.string(),
+  }),
+});

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -403,7 +403,9 @@ const ReportsIndex: NextPage = () => {
                     <Pager
                       size={state.paging.size}
                       page={state.paging.page}
-                      // TODO: Temporary solution, update to handle missing resultsData closer to source?
+                      // TODO: Temporary solution to default to 0.
+                      // Update to handle missing resultsData closer to source or
+                      // Pager to accept undefined count?
                       count={resultsData?.total || 0}
                       onGotoPage={setPage}
                     />

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -322,7 +322,7 @@ const ReportsIndex: NextPage = () => {
 
               {mutation.data &&
                 t('search_result_count', {
-                  count: (resultsData?.hits?.total as SearchTotalHits).value,
+                  count: resultsData?.total,
                 })}
             </header>
 
@@ -332,8 +332,8 @@ const ReportsIndex: NextPage = () => {
               {mutation.isSuccess && mutation.data && (
                 <div>
                   <ul className="space-y-2 divide-y-2">
-                    {resultsData?.hits.hits.map((it, ix) => {
-                      const { _source: doc } = it;
+                    {resultsData?.hits.map((it, ix) => {
+                      const { source: doc } = it;
 
                       // Bail out if we have nothing
                       if (!doc) return null;
@@ -345,7 +345,7 @@ const ReportsIndex: NextPage = () => {
                               {doc.file_name}
                               <span className="text-xs">
                                 Score=
-                                <span className="font-mono">{it._score}</span>
+                                <span className="font-mono">{it.score}</span>
                               </span>
                             </header>
 
@@ -403,7 +403,8 @@ const ReportsIndex: NextPage = () => {
                     <Pager
                       size={state.paging.size}
                       page={state.paging.page}
-                      count={resultsData?.hits.total as number}
+                      // TODO: Temporary solution, update to handle missing resultsData closer to source?
+                      count={resultsData?.total || 0}
                       onGotoPage={setPage}
                     />
                   )}

--- a/frontend/shared/hooks.ts
+++ b/frontend/shared/hooks.ts
@@ -3,12 +3,12 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { DependencyList, useState } from 'react';
 import {
   MsearchBody,
-  SearchResponse,
+  // SearchResponse,
 } from '@opensearch-project/opensearch/api/types';
 import { saveAs } from 'file-saver';
 
 import { getMeta, apiClient, getFile } from 'shared/rest';
-import { IDocument } from 'shared/types';
+import { IDocument, SearchResponse } from 'shared/types';
 
 // #region Queries
 
@@ -47,7 +47,7 @@ export function useSearch() {
     console.assert(query, 'Given search query is invalid; %o', { query });
 
     return apiClient
-      .post<{ result: { body: SearchResponse<IDocument> } }>('/files', query)
+      .post<{ result: { body: SearchResponse } }>('/files', query)
       .then(R.prop('data'));
   });
 }

--- a/frontend/shared/hooks.ts
+++ b/frontend/shared/hooks.ts
@@ -1,14 +1,11 @@
 import * as R from 'rambda';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { DependencyList, useState } from 'react';
-import {
-  MsearchBody,
-  // SearchResponse,
-} from '@opensearch-project/opensearch/api/types';
+import { MsearchBody } from '@opensearch-project/opensearch/api/types';
 import { saveAs } from 'file-saver';
 
 import { getMeta, apiClient, getFile } from 'shared/rest';
-import { IDocument, SearchResponse } from 'shared/types';
+import { SearchResponse } from 'shared/types';
 
 // #region Queries
 

--- a/frontend/shared/types.ts
+++ b/frontend/shared/types.ts
@@ -1,5 +1,3 @@
-// import { SearchResponse } from '@opensearch-project/opensearch/api/types';
-
 /**
  * @deprecated
  */

--- a/frontend/shared/types.ts
+++ b/frontend/shared/types.ts
@@ -1,4 +1,4 @@
-import { SearchResponse } from '@opensearch-project/opensearch/api/types';
+// import { SearchResponse } from '@opensearch-project/opensearch/api/types';
 
 /**
  * @deprecated
@@ -49,7 +49,7 @@ export namespace Rest {
 
   export type Fields = Record<string, Field>;
 
-  export type Reports = SearchResponse<IDocument>;
+  export type Reports = SearchResponse;
 }
 
 //
@@ -61,21 +61,25 @@ export namespace Rest {
  * @see {@link SearchResponse}
  */
 export interface ISearchResult<T> {
-  _index: string;
-  _id: string;
-  _score: number;
-  _source: T;
+  score: number;
+  source: T;
 }
 
 //
 
 export interface IDocument {
-  key: string;
-  file_name: string;
-  bucket_arn: string;
-  bucket_name: string;
-  size: number;
-  metadata: IDocumentMetadata;
+  score?: number;
+  source: {
+    key: string;
+    file_name: string;
+    size: number;
+    metadata: IDocumentMetadata;
+  };
 }
 
 export interface IDocumentMetadata {}
+
+export interface SearchResponse {
+  total: number;
+  hits: Array<IDocument>;
+}

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -23,6 +23,7 @@ import {
   createRaitaBucket,
   createRaitaServiceRole,
 } from './raitaResourceCreators';
+import { getRemovalPolicy } from './utils';
 
 interface DataProcessStackProps extends NestedStackProps {
   readonly raitaStackIdentifier: string;
@@ -95,6 +96,7 @@ export class DataProcessStack extends NestedStack {
       this.createZipHandlerECSResources({
         raitaStackIdentifier,
         vpc,
+        raitaEnv,
       });
 
     dataReceptionBucket.grantRead(handleZipTask.taskRole);
@@ -319,9 +321,11 @@ export class DataProcessStack extends NestedStack {
   private createZipHandlerECSResources({
     raitaStackIdentifier,
     vpc,
+    raitaEnv,
   }: {
     raitaStackIdentifier: string;
     vpc: IVpc;
+    raitaEnv: RaitaEnvironment;
   }) {
     const ecsCluster = new ecs.Cluster(
       this,
@@ -356,15 +360,19 @@ export class DataProcessStack extends NestedStack {
       },
     );
     // Repository for storing docker images
-    const ecsRepo = new ecr.Repository(this, 'repository-raita', {
+    const raitaEcrRepository = new ecr.Repository(this, 'repository-raita', {
       repositoryName: `repository-${raitaStackIdentifier}-zip-handler`,
       lifecycleRules: [{ maxImageCount: 3 }],
       imageScanOnPush: true,
+      removalPolicy: getRemovalPolicy(raitaEnv),
     });
     const handleZipContainer = handleZipTask.addContainer(
       `container-${raitaStackIdentifier}-zip-handler`,
       {
-        image: ecs.ContainerImage.fromEcrRepository(ecsRepo, 'latest'),
+        image: ecs.ContainerImage.fromEcrRepository(
+          raitaEcrRepository,
+          'latest',
+        ),
         logging: new ecs.AwsLogDriver({
           streamPrefix: 'FargateHandleZip',
           logRetention: RetentionDays.SIX_MONTHS,


### PR DESCRIPTION
Pull request modifies meta-endpoint to return only data required by frontend (and other potential api users).

Not tested in feature branch due to Jira 252 (feature endpoint calls to db fail due missing permissions).

Also includes an unrelated chance: adds removalPolicy to Raita ECR container registry (otherwise repos are left hanging after stack removal)