### PR TITLE
fix: RAITA-262 download file with key containing scandic letters

### DIFF
--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
@@ -66,9 +66,9 @@ export async function handleInspectionFileEvent(event: S3Event): Promise<void> {
           spec,
         });
         return {
+          // key is sent to be stored in url decoded format to db
+          key,
           file_name: keyData.fileName,
-          // key is sent to be stored in url decoded format
-          key: keyData.key,
           bucket_arn: eventRecord.s3.bucket.arn,
           bucket_name: eventRecord.s3.bucket.name,
           size: eventRecord.s3.object.size,

--- a/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleReceptionFileEvent/handleReceptionFileEvent.ts
@@ -3,7 +3,7 @@ import { CopyObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { log } from '../../../utils/logger';
 import { getGetEnvWithPreassignedContext } from '../../../../utils';
 import {
-  decodeS3EventPropertyString,
+  getDecodedS3ObjectKey,
   getKeyData,
   isExcelSuffix,
   isZipPath,
@@ -28,7 +28,7 @@ export async function handleReceptionFileEvent(event: S3Event): Promise<void> {
     const recordResults = event.Records.map(async eventRecord => {
       const config = getLambdaConfigOrFail();
       const bucket = eventRecord.s3.bucket;
-      const key = decodeS3EventPropertyString(eventRecord.s3.object.key);
+      const key = getDecodedS3ObjectKey(eventRecord);
       const { path, fileSuffix } = getKeyData(key);
       if (!isZipPath(path)) {
         throw new RaitaLambdaError(`Unexpected file path ${path}`, 400);

--- a/backend/lambdas/raitaApi/handleImagesRequest/handleImagesRequest.ts
+++ b/backend/lambdas/raitaApi/handleImagesRequest/handleImagesRequest.ts
@@ -3,7 +3,6 @@ import { ListObjectsCommand, S3Client } from '@aws-sdk/client-s3';
 import { getEnvOrFail } from '../../../../utils';
 import { log } from '../../../utils/logger';
 import {
-  decodeS3EventPropertyString,
   getRaitaLambdaErrorResponse,
   getRaitaSuccessResponse,
 } from '../../utils';
@@ -33,7 +32,7 @@ export async function handleImagesRequest(
     }
     const { key } = requestBody;
     log.info(user, `Getting related images for ${key}`);
-    const filePath = decodeS3EventPropertyString(key).split('/');
+    const filePath = key.split('/');
     const folderPath = filePath.slice(0, -1);
     const imagesFolderKey = folderPath.concat('jpg').join('/');
     const command = new ListObjectsCommand({

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -1,3 +1,4 @@
+import { S3EventRecord } from 'aws-lambda';
 import {
   ExcelSuffix,
   fileSuffixesToIncudeInMetadataParsing,
@@ -75,13 +76,21 @@ export const getOpenSearchLambdaConfigOrFail = () => {
   };
 };
 
-export const decodeS3EventPropertyString = (s: string) => s.replace(/\+/g, ' ');
+/**
+ * Extract and decode key from S3 event record
+ */
+export const getDecodedS3ObjectKey = (eventRecord: S3EventRecord) =>
+  decodeUriString(eventRecord.s3.object.key).replace(/\+/g, ' ');
 
 export type KeyData = ReturnType<typeof getKeyData>;
+
+/**
+ * Takes in an decoded key and returns extracted informatin from it
+ */
 export const getKeyData = (key: string) => {
   const path = key.split('/');
   const rootFolder = path[0];
-  const fileName = decodeUriString(path[path.length - 1]);
+  const fileName = path[path.length - 1];
   const lastDotInFileName = fileName.lastIndexOf('.');
   const fileBaseName =
     lastDotInFileName >= 0 ? fileName.slice(0, lastDotInFileName) : fileName;

--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -65,7 +65,11 @@ export class RaitaApiStack extends NestedStack {
       policyName: 'service-role/AWSLambdaVPCAccessExecutionRole',
       raitaStackIdentifier,
     });
-    openSearchDomain.grantIndexRead(
+    // Write permission is needed here (the Write part in ReadWrite) as it adds POST permissions to
+    // the metadata index. RaitaApiLambdaServiceRole does not need to make any
+    // data modifications to metadata index but under the hood the client from
+    // @opensearch-project/opensearch utilizes POST to retrieve data from the index.
+    openSearchDomain.grantIndexReadWrite(
       openSearchMetadataIndex,
       this.raitaApiLambdaServiceRole,
     );


### PR DESCRIPTION
Pull request fixes download bug concerning files with keys that contain scandic letters:  the whole file key is now url decoded before it is stored in to the database (previously only file name was url decoded).

Additionally, pull request addresses bug in RAITA-252 by granting POST permissions to api service role to metadata index.