### PR TITLE
Feat/raita 271 virtual run mods

### DIFF
--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
@@ -116,7 +116,7 @@ async function parseFileMetadata({
     keyData,
     spec.fileNameExtractionSpec,
   );
-  const pathData = extractPathData(keyData, spec.folderTreeExtractionSpec);
+  const pathData = extractPathData(keyData, spec);
   const fileContentData =
     shouldParseContent(keyData.fileSuffix) && fileBody
       ? extractFileContentData(spec, fileBody)

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/pathDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/pathDataParser.ts
@@ -6,22 +6,13 @@ import { parsePrimitive } from './parsePrimitives';
 /**
  * Extract meta data from the file path
  */
-export const extractPathData = (
-  keyData: KeyData,
-  folderLabels: IExtractionSpec['folderTreeExtractionSpec'],
-) => {
-  const { path, fileSuffix, fileBaseName } = keyData;
-  // Submission Report Excel files are located higher in the hierarchy than other files which always are at the lowest level,
-  // as quick and dirty solution expectedPathLength for these Excel files is hard coded to 5 which corresponds to their location.
-  // This is a rough implementation which can be replaced with more sofisticated one as the needs for
-  // path data parsing come more clear (is is enough to configure this based on file suffix or if more detailed configration is needed),
-  // more robust solution should be built on modifying the structure in extractionSpec parsing instructions. See Jira 242.
-  const expectedPathLength = isSubmissionReport({ fileBaseName, fileSuffix })
-    ? 5
-    : Object.keys(folderLabels).length;
-  if (path.length !== expectedPathLength) {
+export const extractPathData = (keyData: KeyData, spec: IExtractionSpec) => {
+  const { path } = keyData;
+  // For now, we have to offer support for both folder structures: Virtual run, and the old way.
+  const folderParsingSpec = determineParsingSpec(keyData, spec);
+  if (!folderParsingSpec) {
     logParsingException.warn(
-      `Unexpected folder path length ${path.length} for path ${path}, expected ${expectedPathLength}. Folder path analysis not carried out`,
+      `Unexpected folder path length ${path.length} for path ${path}. Folder path analysis not carried out`,
     );
     return {};
   }
@@ -30,7 +21,7 @@ export const extractPathData = (
   // TODO: Duplicates now implementation for file name parsing
   return folderNames.reduce<ParseValueResult>((acc, cur, index) => {
     // Line below relies on implicit casting number --> string. Note: Index is zero based, keys in dict start from 1
-    const { name, parseAs } = folderLabels[index + 1];
+    const { name, parseAs } = folderParsingSpec[index + 1];
     if (name) {
       const { key, value } = parseAs
         ? parsePrimitive(name, cur, parseAs)
@@ -39,4 +30,22 @@ export const extractPathData = (
     }
     return acc;
   }, {});
+};
+
+ // Submission Report Excel files are located higher in the hierarchy than other files which always are at the lowest level,
+  // as quick and dirty solution expectedPathLength for these Excel files is hard coded to 5 which corresponds to their location.
+  // This is a rough implementation which can be replaced with more sofisticated one as the needs for
+  // path data parsing come more clear (is is enough to configure this based on file suffix or if more detailed configration is needed),
+  // more robust solution should be built on modifying the structure in extractionSpec parsing instructions. See Jira 242.
+const determineParsingSpec = (keyData: KeyData, spec: IExtractionSpec) => {
+  const { fileSuffix, fileBaseName, path } = keyData;
+  switch (true) {
+    case path.length === Object.keys(spec.vRunFolderTreeExtractionSpec).length:
+    case isSubmissionReport({ fileBaseName, fileSuffix }) && path.length === 5:
+      return spec.vRunFolderTreeExtractionSpec;
+    case path.length === Object.keys(spec.folderTreeExtractionSpec).length:
+      return spec.folderTreeExtractionSpec;
+    default:
+      return null;
+  }
 };

--- a/backend/types/specification.ts
+++ b/backend/types/specification.ts
@@ -30,6 +30,7 @@ export const ExtractionSpec = z.object({
     xls: z.record(z.string(), FieldExtractionSpecObject),
   }),
   folderTreeExtractionSpec: z.record(FieldExtractionSpecObject),
+  vRunFolderTreeExtractionSpec: z.record(FieldExtractionSpecObject),
   fileContentExtractionSpec: z.array(ColonSeparatedKeyValuePairDefinition),
 });
 


### PR DESCRIPTION
Virtual run changes the folder structure, so we have to take it into
account when parsing pathData. We now support two different specs for
folder parsing. For this to work, the extractionSpec.json file needs
to have a new field vRunFolderTreeExtractionSpec also.

The example data provided has no difference content or filename -wise 