### PR TITLE
fix: RAITA-200 Use S3 instead of S3client

### DIFF
--- a/backend/lambdas/raitaApi/handlePollingRequest/handlePollingRequest.ts
+++ b/backend/lambdas/raitaApi/handlePollingRequest/handlePollingRequest.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { S3 } from 'aws-sdk';
 import { ALBEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { getEnvOrFail } from '../../../../utils';
 import { log } from '../../../utils/logger';
@@ -18,13 +18,13 @@ function getLambdaConfigOrFail() {
 async function getProgressDataFromS3(
   bucket: string,
   key: string,
-  s3Client: S3Client,
+  s3: S3,
 ) {
-  const command = new GetObjectCommand({
+  const command = {
     Bucket: bucket,
     Key: key,
-  });
-  const data = await s3Client.send(command);
+  };
+  const data = await s3.getObject(command).promise();
   return data?.Body ? JSON.parse(data.Body.toString()) : null;
 }
 
@@ -37,7 +37,7 @@ export async function handlePollingRequest(
   _context: Context,
 ): Promise<APIGatewayProxyResult> {
   const { queryStringParameters } = event;
-  const s3client = new S3Client({});
+  const s3 = new S3();
   try {
     const user = await getUser(event);
     await validateReadUser(user);
@@ -50,7 +50,7 @@ export async function handlePollingRequest(
     const progressData = await getProgressDataFromS3(
       dataBucket,
       queryKey,
-      s3client,
+      s3,
     );
     if (!progressData) {
       throw new RaitaLambdaError('Invalid input', 400);


### PR DESCRIPTION
In most lambdas we use the older s3 api in s3 operations, which has more straight forward way to handle with files. Refactored pollinglambda also to use the older api, to be able to parse the file content.