### PR TITLE
Fix/raita 200 dehydrate large event

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,6 @@ on the stack template. (Cloudformation -> Failed stack -> template tab) and upda
 stack with the modified template. This removed the old target group and its dependencies.
 After this the pipeline could be updated succesfully, and it created all the resources correctly.
 Some references:
+https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-update-rollback-failed/
+https://aws.amazon.com/premiumsupport/knowledge-center/failing-stack-updates-deleted/
+https://www.youtube.com/watch?v=GwbDjuy00Jw

--- a/README.md
+++ b/README.md
@@ -132,3 +132,17 @@ feat(api)!: RAITA-12345 Awesome new feature
 
 Remade API to be more awesome, but with breaking changes
 ```
+
+### Possible problems
+
+If you make changes on the CDK stack files under /lib folder, in some occasions it can
+fail the update on Cloudformation.
+
+One known example of this was after separating a single lambda function into two, without
+modifying the original listener target group, it led into a conflict when updating.
+The original target group couldn't be overwritten and it always led to failure.
+In the end the only way to get it work, was to remove all references of the old target group
+on the stack template. (Cloudformation -> Failed stack -> template tab) and updating that
+stack with the modified template. This removed the old target group and its dependencies.
+After this the pipeline could be updated succesfully, and it created all the resources correctly.
+Some references:

--- a/backend/lambdas/raitaApi/handleZipRequest/constants.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/constants.ts
@@ -14,3 +14,5 @@ export const successProgressData: CompressionProgress = {
   status: ProgressStatus.SUCCESS,
   progressPercentage: 100,
 };
+
+export const invocationTypeByteLimit: number = 262143;

--- a/backend/lambdas/raitaApi/handleZipRequest/handleZipProcessing.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/handleZipProcessing.ts
@@ -115,7 +115,7 @@ export async function handleZipProcessing(event: ZipRequestBody) {
       .getSignedUrlPromise('getObject', {
         Bucket: dataCollectionBucket,
         Key: destKey,
-        Expires: 30,
+        Expires: 600,
       })
       .catch(async err => {
         log.error(

--- a/backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts
@@ -9,13 +9,37 @@ import {
   getRaitaSuccessResponse,
 } from '../../utils';
 import { TextEncoder } from 'util';
+import { invocationTypeByteLimit } from './constants';
+import { S3Client } from '@aws-sdk/client-s3';
+import { ZipRequestBody, uploadDeHydratedToS3 } from './utils';
 
 function getLambdaConfigOrFail() {
   const getEnv = getGetEnvWithPreassignedContext('handleZipRequest');
   return {
     zipProcessingFn: getEnv('ZIP_PROCESSING_FN'),
     region: getEnv('REGION'),
+    targetBucket: getEnv('TARGET_BUCKET'),
   };
+}
+
+async function getPayloadString(
+  requestBody: ZipRequestBody,
+  targetBucket: string,
+  s3Client: S3Client,
+) {
+  const requestBodyString = JSON.stringify(requestBody);
+  if (requestBodyString.length <= invocationTypeByteLimit) {
+    return requestBodyString;
+  } else {
+    const key = `dehydrate/${Date.now()}-${Math.floor(Math.random() * 100)}`;
+    await uploadDeHydratedToS3(targetBucket, key, s3Client, requestBodyString);
+    const dehydratedPayload = {
+      keys: [key],
+      pollingFileKey: requestBody.pollingFileKey,
+      dehydrated: true,
+    };
+    return JSON.stringify(dehydratedPayload);
+  }
 }
 
 export async function handleZipRequest(
@@ -24,21 +48,28 @@ export async function handleZipRequest(
 ): Promise<APIGatewayProxyResult> {
   const { body } = event;
   const requestBody = body && JSON.parse(body);
-  const payloadString = JSON.stringify(requestBody);
-  const payloadBytes = new TextEncoder().encode(payloadString);
+  const s3Client = new S3Client({});
+
   try {
     const user = await getUser(event);
     await validateReadUser(user);
-    const { zipProcessingFn, region } = getLambdaConfigOrFail();
-
-    const client = new LambdaClient({ region });
+    const { zipProcessingFn, region, targetBucket } = getLambdaConfigOrFail();
+    // With the 'InvocationType: Event', the limited payload size is
+    // 262144 bytes. If the payload size exceeds it, we dehydrate the payload
+    // to s3 and pass the s3 key as payload.
+    const payloadString = await getPayloadString(
+      requestBody,
+      targetBucket,
+      s3Client,
+    );
+    const payload = new TextEncoder().encode(payloadString);
+    const lambdaClient = new LambdaClient({ region });
     const command = new InvokeCommand({
       FunctionName: zipProcessingFn,
-      Payload: payloadBytes,
+      Payload: payload,
       InvocationType: 'Event',
     });
-    await client.send(command);
-
+    await lambdaClient.send(command);
     return getRaitaSuccessResponse({
       message: 'Zip processing initiated succesfully',
     });

--- a/backend/lambdas/raitaApi/handleZipRequest/utils.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/utils.ts
@@ -1,8 +1,10 @@
 import {
   PutObjectCommand,
   PutObjectCommandOutput,
+  PutObjectRequest,
   S3Client,
 } from '@aws-sdk/client-s3';
+import { S3 } from 'aws-sdk';
 import { failedProgressData } from './constants';
 
 export async function uploadProgressData(
@@ -17,6 +19,29 @@ export async function uploadProgressData(
     Body: JSON.stringify(progressData),
   });
   return s3Client.send(params);
+}
+
+export async function uploadDeHydratedToS3(
+  bucket: string,
+  key: string,
+  s3Client: S3Client,
+  payload: string,
+) {
+  const params = new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    Body: payload,
+  });
+  return s3Client.send(params);
+}
+
+export async function getJsonObjectFromS3(bucket: string, key: string, s3: S3) {
+  const command = {
+    Bucket: bucket,
+    Key: key,
+  };
+  const data = await s3.getObject(command).promise();
+  return data?.Body ? JSON.parse(data.Body.toString()) : null;
 }
 
 export function shouldUpdateProgressData(
@@ -47,6 +72,12 @@ export interface CompressionProgress {
   status: ProgressStatus;
   progressPercentage: number;
   url?: string | undefined;
+}
+
+export interface ZipRequestBody {
+  keys: string[];
+  pollingFileKey: string;
+  dehydrated?: boolean | undefined;
 }
 
 export enum ProgressStatus {

--- a/frontend/components/loading-overlay.tsx
+++ b/frontend/components/loading-overlay.tsx
@@ -6,7 +6,7 @@ export function LoadingOverlay() {
 
   return (
     <div className="fixed top-0 left-0 right-0 bottom-0 w-full h-screen z-50 overflow-hidden bg-gray-700 opacity-75 flex flex-col items-center justify-center">
-      <Spinner />
+      <Spinner size={12} />
       <h2 className="text-center text-white text-xl font-semibold">
         {t('common:loading')}
       </h2>

--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -83,7 +83,9 @@ export class RaitaApiStack extends NestedStack {
       raitaStackIdentifier,
     });
     inspectionDataBucket.grantRead(this.raitaApiZipProcessLambdaServiceRole);
-    dataCollectionBucket.grantWrite(this.raitaApiZipProcessLambdaServiceRole);
+    dataCollectionBucket.grantReadWrite(
+      this.raitaApiZipProcessLambdaServiceRole,
+    );
 
     // Zip request function only invokes the zipProcess lambda, so
     // we give it a role with only that permission.

--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -158,6 +158,7 @@ export class RaitaApiStack extends NestedStack {
       jwtTokenIssuer,
       lambdaRole: this.raitaApiZipRequestLambdaServiceRole,
       zipProcessingFn: this.handleZipProcessFn.functionName,
+      targetBucket: dataCollectionBucket,
       vpc,
     });
 
@@ -405,6 +406,7 @@ export class RaitaApiStack extends NestedStack {
     jwtTokenIssuer,
     lambdaRole,
     zipProcessingFn,
+    targetBucket,
     vpc,
   }: {
     name: string;
@@ -414,6 +416,7 @@ export class RaitaApiStack extends NestedStack {
     jwtTokenIssuer: string;
     lambdaRole: Role;
     zipProcessingFn: string;
+    targetBucket: Bucket;
     vpc: ec2.IVpc;
   }) {
     return new NodejsFunction(this, name, {
@@ -427,6 +430,7 @@ export class RaitaApiStack extends NestedStack {
         `../backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts`,
       ),
       environment: {
+        TARGET_BUCKET: targetBucket.bucketName,
         ZIP_PROCESSING_FN: zipProcessingFn,
         REGION: this.region,
         JWT_TOKEN_ISSUER: jwtTokenIssuer,


### PR DESCRIPTION
With invocationtype 'event' the sizelimit of payload is 256kb. 

To bypass this, we now dehydrate the payload to s3 