### PR TITLE
fix: RAITA-281 UI clear filters

### DIFF
--- a/frontend/components/filters/multi-choice.tsx
+++ b/frontend/components/filters/multi-choice.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'next-i18next';
-import { ChangeEvent, useRef } from 'react';
+import { ChangeEvent, useEffect, useRef } from 'react';
 
 import { clsx } from 'clsx';
 
@@ -9,17 +9,24 @@ export function MultiChoice(props: Props) {
   const { t } = useTranslation(['common']);
   const ref = useRef<HTMLSelectElement>(null);
 
-  const { items, onChange } = props;
+  const { items, onChange, resetFilters } = props;
+
+  useEffect(() => {
+    if (ref.current && resetFilters) {
+      ref.current.value = '';
+    }
+  }, [resetFilters])
 
   return (
     <div className={clsx(css.root)}>
       <select
+        id='multi-choice'
         multiple={true}
         ref={ref}
         onChange={onChange}
         className={clsx(css.select)}
       >
-        <option value="">{t('common:no_choice')}</option>
+        <option id='empty' value="">{t('common:no_choice')}</option>
         {items.sort((a, b) => a.value > b.value ? 1 : -1)
         .map((it, ix) => {
           return (
@@ -39,6 +46,7 @@ export default MultiChoice;
 
 export type Props = {
   items: Item[];
+  resetFilters: boolean;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 };
 

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -48,6 +48,7 @@ const initialState: ReportsState = {
   text: '',
   filters: {},
   filter: [],
+  resetFilters: false,
   special: {
     dateRange: { start: undefined, end: undefined },
     fileType: undefined,
@@ -179,6 +180,7 @@ const ReportsIndex: NextPage = () => {
 
   const resetSearch = () => {
     setState(() => JSON.parse(JSON.stringify(initialState)) as ReportsState);
+    setState(R.assoc('resetFilters', true));
     mutation.reset();
   };
 
@@ -295,6 +297,7 @@ const ReportsIndex: NextPage = () => {
                     key: it.reportType,
                     value: it.reportType,
                   }))}
+                  resetFilters={state.resetFilters}
                   onChange={e => {
                     setState(
                       R.assocPath(
@@ -317,6 +320,7 @@ const ReportsIndex: NextPage = () => {
                     key: x.value,
                     value: x.value,
                   }))}
+                  resetFilters={state.resetFilters}
                   onChange={e => {
                     setState(
                       R.assocPath(
@@ -339,6 +343,7 @@ const ReportsIndex: NextPage = () => {
                     key: it.value,
                     value: it.value,
                   }))}
+                  resetFilters={state.resetFilters}
                   onChange={e => {
                     setState(
                       R.assocPath(
@@ -362,6 +367,7 @@ const ReportsIndex: NextPage = () => {
                     key: x.fileType,
                     value: x.fileType,
                   }))}
+                  resetFilters={state.resetFilters}
                   onChange={e => {
                     setState(
                       R.assocPath(
@@ -545,6 +551,7 @@ type ReportsState = {
   text: string;
   filters: Record<string, string>;
   filter: Entry[];
+  resetFilters: boolean;
   special: {
     dateRange?: Partial<Range<Date>>;
     fileType?: 'csv' | 'pdf' | 'txt' | 'xlsx';


### PR DESCRIPTION
When the user clicked the clear-button of the multiselects, we did clear the filters from the query, but it 
still looked like the filters were selected on the UI.

Now when clicked, we set all the filters to 'No choice'