### PR TITLE
fix: RAITA-283 Dowload as zip

### DIFF
--- a/backend/lambdas/raitaApi/handleZipRequest/utils.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/utils.ts
@@ -1,11 +1,51 @@
 import {
+  GetObjectCommand,
   PutObjectCommand,
   PutObjectCommandOutput,
-  PutObjectRequest,
   S3Client,
 } from '@aws-sdk/client-s3';
 import { S3 } from 'aws-sdk';
 import { failedProgressData } from './constants';
+import { Readable, PassThrough } from 'stream';
+import { Upload } from '@aws-sdk/lib-storage';
+
+export async function createLazyDownloadStreamFrom(
+  bucket: string,
+  key: string,
+  s3Client: S3Client,
+): Promise<Readable> {
+  let streamCreated = false;
+  // create a dummy stream to pass on
+  const stream = new PassThrough();
+  // only when someone first connects to this stream do we fetch the object and feed the data through the dummy stream
+  stream.on('newListener', async event => {
+    if (!streamCreated && event == 'data') {
+      await initDownloadStream(bucket, key, stream, s3Client);
+      streamCreated = true;
+    }
+  });
+
+  return stream;
+}
+
+export async function uploadZip(
+  bucket: string,
+  key: string,
+  stream: Readable,
+  s3Client: S3Client,
+): Promise<void> {
+  const upload = new Upload({
+    client: s3Client,
+    params: {
+      Bucket: bucket,
+      Key: key,
+      // we pipe to a passthrough to handle the case that the stream isn't initialized yet
+      Body: stream.pipe(new PassThrough()),
+      ContentType: 'application/zip',
+    },
+  });
+  await upload.done();
+}
 
 export async function uploadProgressData(
   progressData: CompressionProgress,
@@ -44,16 +84,6 @@ export async function getJsonObjectFromS3(bucket: string, key: string, s3: S3) {
   return data?.Body ? JSON.parse(data.Body.toString()) : null;
 }
 
-export function shouldUpdateProgressData(
-  progressPercentage: number,
-  lastUpdate: number,
-): boolean {
-  const updateSteps = [25, 50, 75];
-  return (
-    updateSteps.includes(progressPercentage) && progressPercentage > lastUpdate
-  );
-}
-
 export async function updateProgressFailed(
   bucket: string,
   key: string,
@@ -66,6 +96,39 @@ export function validateInputs(keys: string[], pollingFileKey: string) {
   if (!keys.length) throw new Error('No file keys to handle');
   if (!pollingFileKey.length)
     throw new Error('The key of the polling file cannot be empty');
+}
+
+async function initDownloadStream(
+  bucket: string,
+  key: string,
+  stream: PassThrough,
+  s3Client: S3Client,
+) {
+  try {
+    const { Body: body } = await s3Client.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    // we need to type narrow here since Body can be one of many things
+    if (!body) {
+      stream.emit(
+        'error',
+        new Error(
+          `got an undefined body from s3 when getting object ${bucket}/${key}`,
+        ),
+      );
+    } else if (!('on' in body)) {
+      stream.emit(
+        'error',
+        new Error(
+          `got a ReadableStream<any> (a stream used by browser fetch) or Blob from s3 when getting object ${bucket}/${key} instead of Readable`,
+        ),
+      );
+    } else {
+      body.on('error', err => stream.emit('error', err)).pipe(stream);
+    }
+  } catch (e) {
+    stream.emit('error', e);
+  }
 }
 
 export interface CompressionProgress {

--- a/frontend/components/zip-download.tsx
+++ b/frontend/components/zip-download.tsx
@@ -28,9 +28,9 @@ export function ZipDownload(props: Props) {
   const { zipUrl, error, isLoading } = state;
 
   const { t } = useTranslation(['common']);
-  const resultTooBigToCompress =
-    (resultTotalSize && resultTotalSize > 15728640) ||
-    (aggregationSize && aggregationSize > 500);
+  // const resultTooBigToCompress =
+  //   (resultTotalSize && resultTotalSize > 15728640) ||
+  //   (aggregationSize && aggregationSize > 500);
 
   const retryFunction = (failureCount: number) => {
     if (failureCount === 3) {
@@ -94,7 +94,7 @@ export function ZipDownload(props: Props) {
     <div>
       {!zipUrl || error ? (
         <Button
-          disabled={resultTooBigToCompress || isLoading}
+          disabled={isLoading}
           size="sm"
           label={
             isLoading ? (


### PR DESCRIPTION
Current functionality only allows to compress files up to 15mb, or in total 500 files. The problem might relate to stream timeouting on bigger objects as explained here https://gist.github.com/amiantos/16bacc9ed742c91151fcf1a41012445e
)
Modified the original implementation according the typescript example on the link