### PR TITLE
fix: RAITA-283 Download as zip 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The script will deploy CodePipeline, which will automatically set up the environ
 Note! `pipeline:synth` script is used by the pipeline in the build step: If you update the `pipeline:synth` script name, you need to have the old script available for at least one commit in the followed branch or you have to rerun the deployment script by hand.
 
 Note! A valid GitHub token with the scopes `admin:repo_hook, public_repo, repo:status, repo_deployment` is required to be in place in AWS Secrets Manager. Refer to `.lib/raita-pipeline.ts` for authenticationToken name to be set. Set the token as plaintext value.
+Note! If you only update the value of the github token in Secrets Manager, you have to reconnect Github with the CodePipeline. AWS CodePipeline -> Pipeline -> {name_of_pipeline} -> edit pipeline : Edit Source stage and follow the instructions.
 
 Note! If deployment fails to Internal Failure, check that you have GitHub token in _Secrets Manager_!
 

--- a/backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts
@@ -47,10 +47,10 @@ export async function handleZipRequest(
   _context: Context,
 ): Promise<APIGatewayProxyResult> {
   const { body } = event;
-  const requestBody = body && JSON.parse(body);
   const s3Client = new S3Client({});
 
   try {
+    const requestBody = body && JSON.parse(body);
     const user = await getUser(event);
     await validateReadUser(user);
     const { zipProcessingFn, region, targetBucket } = getLambdaConfigOrFail();

--- a/backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/handleZipRequest.ts
@@ -48,7 +48,6 @@ export async function handleZipRequest(
 ): Promise<APIGatewayProxyResult> {
   const { body } = event;
   const s3Client = new S3Client({});
-
   try {
     const requestBody = body && JSON.parse(body);
     const user = await getUser(event);

--- a/backend/lambdas/raitaApi/handleZipRequest/utils.ts
+++ b/backend/lambdas/raitaApi/handleZipRequest/utils.ts
@@ -9,11 +9,11 @@ import { failedProgressData } from './constants';
 import { Readable, PassThrough } from 'stream';
 import { Upload } from '@aws-sdk/lib-storage';
 
-export async function createLazyDownloadStreamFrom(
+export function createLazyDownloadStreamFrom(
   bucket: string,
   key: string,
   s3Client: S3Client,
-): Promise<Readable> {
+): Readable {
   let streamCreated = false;
   // create a dummy stream to pass on
   const stream = new PassThrough();

--- a/frontend/components/daterange.tsx
+++ b/frontend/components/daterange.tsx
@@ -9,6 +9,7 @@ import { Range } from 'shared/types';
 import { DATE_FMT } from 'shared/constants';
 import { assoc } from 'rambda';
 import { useTranslation } from 'next-i18next';
+import { addDays, formatISO } from 'date-fns';
 
 export function DateRange(props: Props) {
   const { t } = useTranslation(['common']);
@@ -19,6 +20,12 @@ export function DateRange(props: Props) {
     start: range?.start,
     end: range?.end,
   });
+
+  function getTomorrowDateString(dateString: string) {
+    const date = new Date(dateString);
+    const tomorrow = addDays(date, 1);
+    return formatISO(tomorrow, { representation: 'date' });
+  }
 
   //
 
@@ -57,7 +64,11 @@ export function DateRange(props: Props) {
             value={rangeValues[0]}
             className={clsx(css.input)}
             onChange={e => {
-              setState(assoc('start', new Date(e.target.value)));
+              const newStartDate = new Date(e.target.value);
+              if (rangeValues[1] && newStartDate > new Date(rangeValues[1])) {
+                setState(assoc('end', undefined));
+              }
+              setState(assoc('start', newStartDate));
             }}
           />
 
@@ -75,11 +86,12 @@ export function DateRange(props: Props) {
             {...{ disabled }}
             type={'date'}
             value={rangeValues[1]}
+            min={
+              rangeValues[0] ? getTomorrowDateString(rangeValues[0]) : undefined
+            }
             className={clsx(css.input)}
             onChange={e => {
-              const selectedDate = new Date(e.target.value);
-              selectedDate.setHours(23, 59, 59);
-              setState(assoc('end', selectedDate));
+              setState(assoc('end', new Date(e.target.value)));
             }}
           />
 

--- a/frontend/components/zip-download.tsx
+++ b/frontend/components/zip-download.tsx
@@ -30,6 +30,7 @@ export function ZipDownload(props: Props) {
   const { t } = useTranslation(['common']);
   const resultTooBigToCompress =
     resultTotalSize && resultTotalSize > 5000000000 ? true : false;
+  const bigCompression = resultTotalSize && resultTotalSize > 1000000000 && !resultTooBigToCompress ? true : false;
 
   const retryFunction = (failureCount: number) => {
     if (failureCount === 3) {
@@ -110,6 +111,9 @@ export function ZipDownload(props: Props) {
           label={`${t('common:download_zip')}`}
           onClick={() => handleZipDownload()}
         />
+      )}
+      {bigCompression && (
+        <p className='text-xs'>{t('common:big_compression')}</p>
       )}
       {error && (
         <div

--- a/frontend/components/zip-download.tsx
+++ b/frontend/components/zip-download.tsx
@@ -28,9 +28,8 @@ export function ZipDownload(props: Props) {
   const { zipUrl, error, isLoading } = state;
 
   const { t } = useTranslation(['common']);
-  // const resultTooBigToCompress =
-  //   (resultTotalSize && resultTotalSize > 15728640) ||
-  //   (aggregationSize && aggregationSize > 500);
+  const resultTooBigToCompress =
+    resultTotalSize && resultTotalSize > 5000000000 ? true : false;
 
   const retryFunction = (failureCount: number) => {
     if (failureCount === 3) {
@@ -94,7 +93,7 @@ export function ZipDownload(props: Props) {
     <div>
       {!zipUrl || error ? (
         <Button
-          disabled={isLoading}
+          disabled={isLoading || resultTooBigToCompress}
           size="sm"
           label={
             isLoading ? (

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -419,13 +419,15 @@ const ReportsIndex: NextPage = () => {
                       count: resultsData?.total,
                     })}
                   </div>
-                  <div className="ml-2">
-                    <ZipDownload
-                      aggregationSize={resultsData?.total}
-                      usedQuery={query}
-                      resultTotalSize={resultsData?.totalSize}
-                    />
-                  </div>
+                  {resultsData?.totalSize && resultsData?.totalSize > 0 && (
+                    <div className="ml-2">
+                      <ZipDownload
+                        aggregationSize={resultsData?.total}
+                        usedQuery={query}
+                        resultTotalSize={resultsData?.totalSize}
+                      />
+                    </div>
+                  )}
                 </div>
               )}
             </header>

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -45,5 +45,6 @@
   "ftia_name": "Finnish Transport Infrastructure Agency",
   "rights_restriction_info": "The use of material stored in the system is restricted by usage rights and allowed only for work related to orders from the Finnish Transport Infrastructure Agency",
   "loading": "Loading...",
-  "too_many_results": "Too many results, try filtering your search more"
+  "too_many_results": "Too many results, try filtering your search more",
+  "big_compression": "Note! Compressing a lot of data might take several minutes"
 }

--- a/frontend/public/locales/fi/common.json
+++ b/frontend/public/locales/fi/common.json
@@ -48,5 +48,6 @@
   "ftia_name": "Väylävirasto",
   "rights_restriction_info": "Järjestelmään tallennetun aineiston käyttö on käyttöoikeuksilla rajoitettua ja sallittua vain Väyläviraston tilauksiin liittyvissä töissä.",
   "loading": "Ladataan...",
-  "too_many_results": "Haku tuotti yli 10k tulosta, rajaa hakua tarkemmin"
+  "too_many_results": "Haku tuotti yli 10k tulosta, rajaa hakua tarkemmin",
+  "big_compression": "Huom! Ison datamäärän pakkaaminen voi viedä useita minuutteja"
 }

--- a/lib/raita-api.ts
+++ b/lib/raita-api.ts
@@ -65,13 +65,15 @@ export class RaitaApiStack extends NestedStack {
     } = props;
 
     // Create a bucket to hold the data of user made
-    // collections as a zip.
+    // collections as a zip. Set lifecycle policy to delete
+    // the objects in 30 days
     const dataCollectionBucket = createRaitaBucket({
       scope: this,
       name: 'data-collection',
       raitaEnv,
       raitaStackIdentifier,
     });
+    dataCollectionBucket.addLifecycleRule({expiration: cdk.Duration.days(30)});
 
     // ZipProcesser needs rights to two buckets so it gets its
     // own role with proper permissions.
@@ -512,8 +514,8 @@ export class RaitaApiStack extends NestedStack {
   }) {
     return new NodejsFunction(this, name, {
       functionName: `lambda-${raitaStackIdentifier}-${name}`,
-      memorySize: 1768,
-      timeout: cdk.Duration.minutes(10),
+      memorySize: 3008,
+      timeout: cdk.Duration.minutes(15),
       runtime: lambda.Runtime.NODEJS_16_X,
       handler: 'handleZipProcessing',
       entry: path.join(


### PR DESCRIPTION
Fine tuning for the zipping functionality, changed the size restriction of the files to be zipped to 5GB instead of 15mb. Removed unnecessary async from createLazyDownloadStreamFrom function, updated documentation concerning the change of github token in secrets manager