### PR TITLE
feat: SOA Office bucket policies

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -37,7 +37,10 @@ export const SSM_CLOUDFRONT_CERTIFICATE_ARN =
 export const SSM_CLOUDFRONT_DOMAIN_NAME = 'raita-cloudfront-domain-name';
 export const SSM_DMZ_API_DOMAIN_NAME = 'raita-dmz-api-domain-name';
 export const SFTP_POLICY_ACCOUNT_ID = 'raita-sftp-policy-account-id';
+export const SOA_POLICY_ACCOUNT_ID = 'raita-soa-policy-account-id';
 export const SFTP_POLICY_USER_ID = 'raita-sftp-policy-user-id';
+export const VAYLA_POLICY_USER_ID = 'raita-vayla-policy-user-id';
+export const LORAM_POLICY_USER_ID = 'raita-loram-policy-user-id';
 export const SSM_JWT_TOKEN_ISSUER = 'raita-jwt-token-issuer';
 export const SSM_API_KEY = 'raita-api-key';
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,10 @@
-import { raitaSourceSystems, SSM_JWT_TOKEN_ISSUER } from '../constants';
+import {
+  LORAM_POLICY_USER_ID,
+  raitaSourceSystems,
+  SOA_POLICY_ACCOUNT_ID,
+  SSM_JWT_TOKEN_ISSUER,
+  VAYLA_POLICY_USER_ID,
+} from '../constants';
 import { getEnvOrFail } from '../utils';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 // import { Construct } from '@aws-cdk/core';
@@ -123,6 +129,9 @@ export const getRaitaStackConfig = (
   dmzApiEndpoint: getSSMParameter(scope, SSM_DMZ_API_DOMAIN_NAME),
   sftpPolicyAccountId: getSSMParameter(scope, SFTP_POLICY_ACCOUNT_ID),
   sftpPolicyUserId: getSSMParameter(scope, SFTP_POLICY_USER_ID),
+  soaPolicyAccountId: getSSMParameter(scope, SOA_POLICY_ACCOUNT_ID),
+  vaylaPolicyUserId: getSSMParameter(scope, VAYLA_POLICY_USER_ID),
+  loramPolicyUserId: getSSMParameter(scope, LORAM_POLICY_USER_ID),
   jwtTokenIssuer: getSSMParameter(scope, SSM_JWT_TOKEN_ISSUER),
   ...getAccountVpcResourceConfig(raitaEnv),
 });

--- a/lib/raita-application.ts
+++ b/lib/raita-application.ts
@@ -23,6 +23,9 @@ interface ApplicationStackProps extends NestedStackProps {
   readonly parserConfigurationFile: string;
   readonly sftpPolicyAccountId: string;
   readonly sftpPolicyUserId: string;
+  readonly soaPolicyAccountId: string;
+  readonly vaylaPolicyUserId: string;
+  readonly loramPolicyUserId: string;
   readonly cloudfrontDomainName: string;
 }
 
@@ -43,6 +46,9 @@ export class ApplicationStack extends NestedStack {
       parserConfigurationFile,
       sftpPolicyAccountId,
       sftpPolicyUserId,
+      soaPolicyAccountId,
+      vaylaPolicyUserId,
+      loramPolicyUserId,
       cloudfrontDomainName,
     } = props;
 
@@ -64,6 +70,9 @@ export class ApplicationStack extends NestedStack {
       parserConfigurationFile: parserConfigurationFile,
       sftpPolicyAccountId: sftpPolicyAccountId,
       sftpPolicyUserId: sftpPolicyUserId,
+      soaPolicyAccountId: soaPolicyAccountId,
+      vaylaPolicyUserId: vaylaPolicyUserId,
+      loramPolicyUserId: loramPolicyUserId,
     });
 
     // Create API Gateway
@@ -106,7 +115,9 @@ export class ApplicationStack extends NestedStack {
       name: 'ApiParameterStorePolicy',
       raitaStackIdentifier,
       serviceRoles: [raitaApiStack.raitaApiLambdaServiceRole],
-      resources: [`arn:aws:ssm:${this.region}:${this.account}:parameter/${SSM_API_KEY}`],
+      resources: [
+        `arn:aws:ssm:${this.region}:${this.account}:parameter/${SSM_API_KEY}`,
+      ],
       actions: ['ssm:GetParameter'],
     });
 

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -125,7 +125,7 @@ export class DataProcessStack extends NestedStack {
     // Grant SOA-offices loram role read access to data reception bucket
     const soaOfficeLoramBucketPolicy = this.createBucketPolicy({
       policyAccountId: soaPolicyAccountId,
-      policyUserId: vaylaPolicyUserId,
+      policyUserId: loramPolicyUserId,
       resources: [
         dataReceptionBucket.bucketArn,
         `${dataReceptionBucket.bucketArn}/${raitaSourceSystems.Meeri}/*`,

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -34,6 +34,9 @@ interface DataProcessStackProps extends NestedStackProps {
   readonly parserConfigurationFile: string;
   readonly sftpPolicyAccountId: string;
   readonly sftpPolicyUserId: string;
+  readonly soaPolicyAccountId: string;
+  readonly vaylaPolicyUserId: string;
+  readonly loramPolicyUserId: string;
 }
 
 export class DataProcessStack extends NestedStack {
@@ -52,6 +55,9 @@ export class DataProcessStack extends NestedStack {
       parserConfigurationFile,
       sftpPolicyAccountId,
       sftpPolicyUserId,
+      soaPolicyAccountId,
+      vaylaPolicyUserId,
+      loramPolicyUserId,
     } = props;
 
     this.dataProcessorLambdaServiceRole = createRaitaServiceRole({
@@ -84,12 +90,55 @@ export class DataProcessStack extends NestedStack {
     });
 
     // Grant sftpUser access to data reception bucket
-    const sftpReceivePolicy = this.createSftpReceivePolicy({
-      sftpPolicyAccountId,
-      sftpPolicyUserId,
-      dataReceptionBucket,
+    const sftpReceivePolicy = this.createBucketPolicy({
+      policyAccountId: sftpPolicyAccountId,
+      policyUserId: sftpPolicyUserId,
+      resources: [
+        dataReceptionBucket.bucketArn,
+        `${dataReceptionBucket.bucketArn}/${raitaSourceSystems.Meeri}/*`,
+      ],
+      actions: [
+        's3:GetObject',
+        's3:GetObjectVersion',
+        's3:GetObjectAcl',
+        's3:PutObject',
+        's3:PutObjectAcl',
+        's3:ListBucket',
+        's3:GetBucketLocation',
+        's3:DeleteObject',
+      ],
     });
     dataReceptionBucket.addToResourcePolicy(sftpReceivePolicy);
+
+    // Grant SOA-offices väylä role full access to data reception bucket
+    const soaOfficeVaylaBucketPolicy = this.createBucketPolicy({
+      policyAccountId: soaPolicyAccountId,
+      policyUserId: vaylaPolicyUserId,
+      resources: [
+        dataReceptionBucket.bucketArn,
+        `${dataReceptionBucket.bucketArn}/${raitaSourceSystems.Meeri}/*`,
+      ],
+      actions: ['s3:ListBucket', 's3:GetBucketLocation', 's3:*Object'],
+    });
+    dataReceptionBucket.addToResourcePolicy(soaOfficeVaylaBucketPolicy);
+
+    // Grant SOA-offices loram role read access to data reception bucket
+    const soaOfficeLoramBucketPolicy = this.createBucketPolicy({
+      policyAccountId: soaPolicyAccountId,
+      policyUserId: vaylaPolicyUserId,
+      resources: [
+        dataReceptionBucket.bucketArn,
+        `${dataReceptionBucket.bucketArn}/${raitaSourceSystems.Meeri}/*`,
+      ],
+      actions: [
+        's3:ListBucket',
+        's3:GetBucketLocation',
+        's3:GetObject',
+        's3:GetObjectVersion',
+        's3:GetObjectAcl',
+      ],
+    });
+    dataReceptionBucket.addToResourcePolicy(soaOfficeLoramBucketPolicy);
 
     // Create ECS cluster resources for zip extraction task
     const { ecsCluster, handleZipTask, handleZipContainer } =
@@ -272,37 +321,28 @@ export class DataProcessStack extends NestedStack {
   }
 
   /**
-   * Creates a policy permitting sftpUser access to data reception bucket
+   * Helper to create bucket policies
    */
-  private createSftpReceivePolicy({
-    sftpPolicyAccountId,
-    dataReceptionBucket,
-    sftpPolicyUserId,
+
+  private createBucketPolicy({
+    policyAccountId,
+    policyUserId,
+    resources,
+    actions,
   }: {
-    sftpPolicyAccountId: string;
-    sftpPolicyUserId: string;
-    dataReceptionBucket: Bucket;
+    policyAccountId: string;
+    policyUserId: string;
+    resources: Array<string>;
+    actions: Array<string>;
   }) {
     return new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
-      principals: [new iam.AccountPrincipal(sftpPolicyAccountId)],
-      actions: [
-        's3:GetObject',
-        's3:GetObjectVersion',
-        's3:GetObjectAcl',
-        's3:PutObject',
-        's3:PutObjectAcl',
-        's3:ListBucket',
-        's3:GetBucketLocation',
-        's3:DeleteObject',
-      ],
-      resources: [
-        dataReceptionBucket.bucketArn,
-        `${dataReceptionBucket.bucketArn}/${raitaSourceSystems.Meeri}/*`,
-      ],
+      principals: [new iam.AccountPrincipal(policyAccountId)],
+      actions,
+      resources,
       conditions: {
         StringLike: {
-          'aws:userId': `${sftpPolicyUserId}:*`,
+          'aws:userId': `${policyUserId}:*`,
         },
       },
     });

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -118,7 +118,16 @@ export class DataProcessStack extends NestedStack {
         dataReceptionBucket.bucketArn,
         `${dataReceptionBucket.bucketArn}/${raitaSourceSystems.Meeri}/*`,
       ],
-      actions: ['s3:ListBucket', 's3:GetBucketLocation', 's3:*Object'],
+      actions: [
+        's3:GetObject',
+        's3:GetObjectVersion',
+        's3:GetObjectAcl',
+        's3:PutObject',
+        's3:PutObjectAcl',
+        's3:ListBucket',
+        's3:GetBucketLocation',
+        's3:DeleteObject',
+      ],
     });
     dataReceptionBucket.addToResourcePolicy(soaOfficeVaylaBucketPolicy);
 

--- a/lib/raita-stack.ts
+++ b/lib/raita-stack.ts
@@ -44,6 +44,9 @@ export class RaitaStack extends Stack {
       parserConfigurationFile: config.parserConfigurationFile,
       sftpPolicyAccountId: config.sftpPolicyAccountId,
       sftpPolicyUserId: config.sftpPolicyUserId,
+      soaPolicyAccountId: config.soaPolicyAccountId,
+      vaylaPolicyUserId: config.vaylaPolicyUserId,
+      loramPolicyUserId: config.loramPolicyUserId,
       cloudfrontDomainName: config.cloudfrontDomainName,
     });
     Object.entries(tags).forEach(([key, value]) =>


### PR DESCRIPTION
New bucket policies to allow SOA offices väylä and loram roles to do operations on the data
reception bucket. Also refactored the policy creation functionality