### PR TITLE
RAITA-319 Add workaround for using api locally

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -3,8 +3,6 @@ import { devApiKey, devApiUrl } from 'shared/config';
 
 /**
  * Overwrite api requests in dev environment
- *
- * TODO: this should only run in local dev environment
  */
 export async function middleware(request: NextRequest) {
   if (devApiUrl && devApiKey) {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from 'next/server';
+import { devApiKey, devApiUrl } from 'shared/config';
+
+/**
+ * Overwrite api requests in dev environment
+ *
+ * TODO: this should only run in local dev environment
+ */
+export async function middleware(request: NextRequest) {
+  if (devApiUrl && devApiKey) {
+    const path = request.nextUrl.pathname;
+    const apiPart = `${path.slice(path.indexOf('/api') + 4)}`;
+    const newUrl = `${devApiUrl}${apiPart}`;
+    if (request.method === 'GET') {
+      return fetch(newUrl, {
+        method: 'GET',
+        headers: { 'x-api-key': devApiKey },
+      });
+    }
+    if (request.method === 'POST') {
+      const newBody = await request.json();
+      return fetch(newUrl, {
+        method: 'POST',
+        body: JSON.stringify(newBody),
+        headers: { 'x-api-key': devApiKey },
+      });
+    }
+  }
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};

--- a/frontend/shared/config.ts
+++ b/frontend/shared/config.ts
@@ -9,6 +9,12 @@ export const openSearch = {
 export const baseURL =
   process.env.NEXT_PUBLIC_API_BASEURL || process.env.API_BASEURL || '/api';
 
+/**
+ * Overwrite api requests for dev environment
+ */
+export const devApiUrl = process.env.DEV_RAITA_API_BASEURL || null;
+export const devApiKey = process.env.DEV_RAITA_API_KEY || null;
+
 export const paging = {
   pageSize: 10,
 } as const;


### PR DESCRIPTION
Add a middleware for redirecting api requests to bastion pipe locally.

The middleware is not used in production, so this only affects the local dev environment