### PR TITLE
RAITA-306/RAITA-326 Fix for timestamp search 

### DIFF
--- a/frontend/shared/__tests__/query-builder.ts
+++ b/frontend/shared/__tests__/query-builder.ts
@@ -150,4 +150,60 @@ describe('paged queries', () => {
     expect(r1).toEqual(e1);
     expect(r2).toEqual(e2);
   });
+
+  it('should translate inspection_datetime range query to an OR query', () => {
+    const entries: Entry[] = [
+      {
+        field: 'inspection_datetime',
+        value: '2023-01-01T00:00:00.000Z',
+        type: 'range',
+        rel: 'gte',
+      },
+      {
+        field: 'inspection_datetime',
+        value: '2023-01-02T00:00:00.000Z',
+        type: 'range',
+        rel: 'lte',
+      },
+    ];
+
+    const q = makeQuery(entries, { keyFn: a => a });
+    expect(q).toEqual({
+      aggs: {
+        total_size: {
+          sum: {
+            field: 'size',
+          },
+        },
+      },
+      query: {
+        bool: {
+          must: [
+            {
+              bool: {
+                should: [
+                  {
+                    range: {
+                      inspection_datetime: {
+                        gte: '2023-01-01T00:00:00.000Z',
+                        lte: '2023-01-02T00:00:00.000Z',
+                      },
+                    },
+                  },
+                  {
+                    range: {
+                      inspection_date: {
+                        gte: '2023-01-01T00:00:00.000Z',
+                        lte: '2023-01-02T00:00:00.000Z',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
In frontend: translate a inspecton_datetime metadata query to an OR query between inspection_datetime and inspection_date in the makeQuery function.

This is a (temporary?) solution for the problem where some files are missing the inspection_datetime field but they still have the inspection_date field. However it is possible that old data does not have the inspection_date field.

Added a unit test to test the query translation
