### PR TITLE
RAITA-323: Parser unit tests

### DIFF
--- a/backend/lambdas/__tests__/utils.test.ts
+++ b/backend/lambdas/__tests__/utils.test.ts
@@ -1,0 +1,28 @@
+import { getKeyData } from '../utils';
+
+describe('getKeyData', () => {
+  test('success: normal path', () => {
+    const key = 'path/to/file/1/file_123.txt';
+    const result = getKeyData(key);
+    expect(result).toEqual({
+      path: ['path', 'to', 'file', '1', 'file_123.txt'],
+      rootFolder: 'path',
+      fileName: 'file_123.txt',
+      fileBaseName: 'file_123',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'path/to/file/1/file_123',
+    });
+  });
+  test('success: filename only', () => {
+    const key = 'file_123.txt';
+    const result = getKeyData(key);
+    expect(result).toEqual({
+      path: ['file_123.txt'],
+      rootFolder: 'file_123.txt', // TODO: should this be empty?
+      fileName: 'file_123.txt',
+      fileBaseName: 'file_123',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'file_123',
+    });
+  });
+});

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/contentDataParser.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/contentDataParser.test.ts
@@ -1,0 +1,51 @@
+import { shouldParseContent } from '../contentDataParser';
+
+jest.mock('../../../../utils/logger', () => {
+  return {
+    log: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+    },
+    logParsingException: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+const extractionSpec = {
+  fileNameExtractionSpec: {},
+  folderTreeExtractionSpec: {
+    '1': { name: 'part1' },
+    '2': { name: 'part2' },
+    '3': { name: 'part3' },
+    '4': { name: 'filename' },
+  },
+  vRunFolderTreeExtractionSpec: {
+    '1': { name: 'vPart1' },
+    '2': { name: 'filename' },
+  },
+  fileContentExtractionSpec: {},
+};
+
+describe('shouldParseContent', () => {
+  test('success: txt file', () => {
+    expect(shouldParseContent('txt')).toBe(true);
+  });
+  test('fail: other files', () => {
+    expect(shouldParseContent('csv')).toBe(false);
+    expect(shouldParseContent('pdf')).toBe(false);
+    expect(shouldParseContent('xlsx')).toBe(false);
+    expect(shouldParseContent('xls')).toBe(false);
+    expect(shouldParseContent('exe')).toBe(false);
+  });
+});
+describe('extractFileContentData', () => {
+  test('success: txt file', () => {
+    // TODO
+  });
+});

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/fileNameDataParser.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/fileNameDataParser.test.ts
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import { IExtractionSpec, IExtractionSpecLabels } from '../../../../types';
 import { KeyData } from '../../../utils';
 import {

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/fileNameDataParser.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/fileNameDataParser.test.ts
@@ -1,0 +1,225 @@
+import { format } from 'date-fns';
+import { IExtractionSpec, IExtractionSpecLabels } from '../../../../types';
+import { KeyData } from '../../../utils';
+import {
+  extractFileNameData,
+  parseFileNameParts,
+  validateGenericFileNameStructureOrFail,
+} from '../fileNameDataParser';
+
+jest.mock('../../../../utils/logger', () => {
+  return {
+    log: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+    },
+    logParsingException: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+describe('parseFileNameParts', () => {
+  test('success', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'count' },
+      '3': { name: 'length' },
+    };
+    const fileNameParts = ['testName', '123', '100.5'];
+    const result = parseFileNameParts(extractionSpecLabels, fileNameParts);
+    expect(result).toEqual({
+      name: 'testName',
+      count: '123',
+      length: '100.5',
+    });
+  });
+  test('success with EMPTY suffix', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'test' },
+    };
+    const fileNameParts = ['testName', 'test', 'EMPTY'];
+    const result = parseFileNameParts(extractionSpecLabels, fileNameParts);
+    expect(result).toEqual({
+      name: 'testName',
+      test: 'test',
+      isEmpty: true,
+    });
+  });
+});
+describe('validateGenericFileNameStructureOrFail', () => {
+  test('success', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    };
+    const fileName = 'test_123_456.txt';
+    const fileNameParts = ['test', '123', '456'];
+    const result = validateGenericFileNameStructureOrFail(
+      fileName,
+      extractionSpecLabels,
+      fileNameParts,
+    );
+    expect(result).toBe(undefined);
+  });
+  test('success with EMPTY suffix', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    };
+    const fileName = 'test_123_456_EMPTY.txt';
+    const fileNameParts = ['test', '123', '456', 'EMPTY'];
+    const result = validateGenericFileNameStructureOrFail(
+      fileName,
+      extractionSpecLabels,
+      fileNameParts,
+    );
+    expect(result).toBe(undefined);
+  });
+  test('fail: too many name segments', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+    };
+    const fileName = 'test_123_456_.txt';
+    const fileNameParts = ['test', '123', '456'];
+    expect(() =>
+      validateGenericFileNameStructureOrFail(
+        fileName,
+        extractionSpecLabels,
+        fileNameParts,
+      ),
+    ).toThrow();
+  });
+  test('fail: too few name segments', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    };
+    const fileName = 'test_123.txt';
+    const fileNameParts = ['test', '123'];
+    expect(() =>
+      validateGenericFileNameStructureOrFail(
+        fileName,
+        extractionSpecLabels,
+        fileNameParts,
+      ),
+    ).toThrow();
+  });
+  test('fail: too few name segments with EMPTY', () => {
+    const extractionSpecLabels: IExtractionSpecLabels = {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    };
+    const fileName = 'test_123_EMPTY.txt';
+    const fileNameParts = ['test', '123', 'EMPTY'];
+    expect(() =>
+      validateGenericFileNameStructureOrFail(
+        fileName,
+        extractionSpecLabels,
+        fileNameParts,
+      ),
+    ).toThrow();
+  });
+});
+describe('extractFileNameData', () => {
+  const extractionSpec: IExtractionSpec['fileNameExtractionSpec'] = {
+    txt: {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    },
+    csv: {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    },
+    pdf: {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    },
+    xlsx: {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    },
+    xls: {
+      '1': { name: 'name' },
+      '2': { name: 'test1' },
+      '3': { name: 'test2' },
+    },
+  };
+  test('success', () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', 'test_123_456.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456.txt',
+      fileBaseName: 'test_123_456',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/path/test_123_456',
+    };
+    const result = extractFileNameData(keyData, extractionSpec);
+    expect(result).toEqual({
+      file_type: 'txt',
+      name: 'test',
+      test1: '123',
+      test2: '456',
+    });
+  });
+  test('fail: too many file name segments', () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', 'test_123_456_789.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456_789.txt',
+      fileBaseName: 'test_123_456_789',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/path/test_123_456_789',
+    };
+    const result = extractFileNameData(keyData, extractionSpec);
+    expect(result).toEqual({});
+  });
+  test('fail: missing keydata fields', () => {
+    const keyData1 = {
+      path: ['test', 'path', 'test_123_456_789.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456_789.txt',
+      fileBaseName: 'test_123_456_789',
+      keyWithoutSuffix: 'test/path/test_123_456_789',
+    };
+    const keyData2 = {
+      path: ['test', 'path', 'test_123_456_789.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456_789.txt',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/path/test_123_456_789',
+    };
+    expect(extractFileNameData(keyData1 as KeyData, extractionSpec)).toEqual(
+      {},
+    );
+    expect(extractFileNameData(keyData2 as KeyData, extractionSpec)).toEqual(
+      {},
+    );
+  });
+  test('fail: wrong file type', () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', 'test_123_456_789.exe'],
+      rootFolder: 'test',
+      fileName: 'test_123_456_789.exe',
+      fileBaseName: 'test_123_456_789',
+      fileSuffix: 'exe',
+      keyWithoutSuffix: 'test/path/test_123_456_789',
+    };
+    expect(extractFileNameData(keyData, extractionSpec)).toEqual({});
+  });
+});

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/parseFileMetaData.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/parseFileMetaData.test.ts
@@ -1,0 +1,165 @@
+import { IExtractionSpec } from '../../../../types';
+import { KeyData } from '../../../utils';
+import { parseFileMetadata } from '../parseFileMetadata';
+
+jest.mock('../../../../utils/logger', () => {
+  return {
+    log: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+    logParsingException: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+const extractionSpec: IExtractionSpec = {
+  fileNameExtractionSpec: {
+    txt: {
+      '1': { name: 'nameOnly1' },
+      '2': { name: 'overlapping' },
+      '3': { name: 'nameOnly2', parseAs: 'integer' },
+    },
+    csv: {
+      '1': { name: 'nameOnly1' },
+      '2': { name: 'overlapping' },
+      '3': { name: 'nameOnly2', parseAs: 'integer' },
+    },
+    pdf: {
+      '1': { name: 'nameOnly1' },
+      '2': { name: 'overlapping' },
+      '3': { name: 'nameOnly2', parseAs: 'integer' },
+    },
+    xlsx: {
+      '1': { name: 'nameOnly1' },
+      '2': { name: 'overlapping' },
+      '3': { name: 'nameOnly2', parseAs: 'integer' },
+    },
+    xls: {
+      '1': { name: 'nameOnly1' },
+      '2': { name: 'overlapping' },
+      '3': { name: 'nameOnly2', parseAs: 'integer' },
+    },
+  },
+  folderTreeExtractionSpec: {
+    '1': { name: 'pathOnly1' },
+    '2': { name: 'pathOnly2' },
+    '3': { name: 'overlapping' },
+    '4': { name: 'filename' },
+  },
+  vRunFolderTreeExtractionSpec: {
+    '1': { name: 'pathOnly1' },
+    '2': { name: 'vPathOnly2' },
+  },
+  fileContentExtractionSpec: [],
+};
+
+const dummyHash =
+  'b5a2c96250612366ea272ffac6d9744aaf4b45aacd96aa7cfcb931ee3b558259';
+
+describe('parseFileMetadata', () => {
+  test('success: normal .txt', async () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', 'FROMPATH', 'TEST_FROMNAME_112233.txt'],
+      rootFolder: 'test',
+      fileName: 'TEST_FROMNAME_112233.txt',
+      fileBaseName: 'TEST_FROMNAME_112233',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/path/FROMPATH/TEST_FROMNAME_112233',
+    };
+    const fileData = {
+      fileBody: 'dummy',
+      contentType: 'text/plain',
+      tags: {}, // TODO what is this
+    };
+    const params = {
+      keyData,
+      file: fileData,
+      spec: extractionSpec,
+    };
+    const result = await parseFileMetadata(params);
+    expect(result).toEqual({
+      hash: dummyHash,
+      metadata: {
+        file_type: 'txt',
+        pathOnly1: 'test',
+        pathOnly2: 'path',
+        nameOnly1: 'TEST',
+        nameOnly2: 112233,
+        overlapping: 'FROMNAME',
+      },
+    });
+  });
+  test('partial: malformed filename, .csv', async () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', 'FROMPATH', 'TOO_MAY_NAME_SEGMENTS_HERE.csv'],
+      rootFolder: 'test',
+      fileName: 'TOO_MAY_NAME_SEGMENTS_HERE.csv',
+      fileBaseName: 'TOO_MAY_NAME_SEGMENTS_HERE',
+      fileSuffix: 'csv',
+      keyWithoutSuffix: 'test/path/FROMPATH/TOO_MAY_NAME_SEGMENTS_HERE',
+    };
+    const fileData = {
+      fileBody: 'dummy',
+      contentType: 'text/csv',
+      tags: {}, // TODO what is this
+    };
+    const params = {
+      keyData,
+      file: fileData,
+      spec: extractionSpec,
+    };
+    const result = await parseFileMetadata(params);
+    expect(result).toEqual({
+      hash: dummyHash,
+      metadata: {
+        // data from name missing
+        overlapping: 'FROMPATH',
+        pathOnly1: 'test',
+        pathOnly2: 'path',
+      },
+    });
+  });
+  test('partial: malformed path, .csv', async () => {
+    const keyData: KeyData = {
+      path: ['TOO', 'LONG', 'PATH', 'HERE', 'TEST_FROMNAME_112233.csv'],
+      rootFolder: 'TOO',
+      fileName: 'TEST_FROMNAME_112233.csv',
+      fileBaseName: 'TEST_FROMNAME_112233',
+      fileSuffix: 'csv',
+      keyWithoutSuffix: 'TOO/LONG/PATH/HERE/TEST_FROMNAME_112233',
+    };
+    const fileData = {
+      fileBody: 'dummy',
+      contentType: 'text/csv',
+      tags: {}, // TODO what is this
+    };
+    const params = {
+      keyData,
+      file: fileData,
+      spec: extractionSpec,
+    };
+    const result = await parseFileMetadata(params);
+    expect(result).toEqual({
+      hash: dummyHash,
+      metadata: {
+        file_type: 'csv',
+        nameOnly1: 'TEST',
+        nameOnly2: 112233,
+        overlapping: 'FROMNAME',
+      },
+    });
+  });
+  test.skip('success: parse submission report .xlsx', () => {});
+  test.skip('partial: malformed filename, .txt', () => {});
+  test.skip('partial: malformed path, .txt', () => {});
+  test.skip('partial: malformed content, .txt', () => {});
+});

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/parsePrimitives.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/parsePrimitives.test.ts
@@ -34,33 +34,36 @@ describe('parsePrimitive', () => {
       value: NaN, // TODO: should show error?
     });
   });
-  test('success: multiple date formats', () => {
-    // multiple different date formats accepted
-    // TODO: times are checked in current timezone
-    const date1 = format(new Date('2023-09-19T18:00:00.000Z'), 'd/M/y h:m:s a');
-    const date2 = format(
+  test('success: format d/M/y h:m:s a', () => {
+    const date = format(new Date('2023-09-19T18:00:00.000Z'), 'd/M/y h:m:s a');
+    const result = parsePrimitive('test', date, 'date');
+
+    expect(result).toEqual({
+      key: 'test',
+      value: '2023-09-19T18:00:00.000Z',
+    });
+  });
+  test.skip('success: format yyyyMMdd_hhmmss', () => {
+    // TODO: only dates in 12h formats are accepted, is this intentional?
+    const date = format(
       new Date('2023-09-19T18:00:00.000Z'),
       'yyyyMMdd_HHmmss',
     );
-    const date3 = format(new Date('2023-09-19'), 'yyyyMMdd');
-    const result1 = parsePrimitive('test', date1, 'date');
-    // const result2 = parsePrimitive('test', date2, 'date');
-    // const result3 = parsePrimitive('test', date3, 'date');
-    const expectedDateTime = '2023-09-19T18:00:00.000Z';
-    const expectedDateOnly = '2023-09-19T00:00:00.000Z';
+    const result = parsePrimitive('test', date, 'date');
 
-    expect(result1).toEqual({
+    expect(result).toEqual({
       key: 'test',
-      value: expectedDateTime,
+      value: '2023-09-19T18:00:00.000Z',
     });
-    // TODO: fix these
-    // expect(result2).toEqual({
-    //   key: 'test',
-    //   value: expectedDateTime,
-    // });
-    // expect(result3).toEqual({
-    //   key: 'test',
-    //   value: expectedDateOnly,
-    // });
+  });
+  test.skip('success: format yyyyMMdd', () => {
+    // TODO: returning wrong date because of timezone?
+    const date = format(new Date('2023-09-19'), 'yyyyMMdd');
+    const result = parsePrimitive('test', date, 'date');
+
+    expect(result).toEqual({
+      key: 'test',
+      value: '2023-09-19T00:00:00.000Z',
+    });
   });
 });

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/parsePrimitives.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/parsePrimitives.test.ts
@@ -1,0 +1,66 @@
+import format from 'date-fns/format';
+import { parsePrimitive } from '../parsePrimitives';
+
+describe('parsePrimitive', () => {
+  test('success: integer', () => {
+    const data = '123';
+    const result = parsePrimitive('test', data, 'integer');
+    expect(result).toEqual({
+      key: 'test',
+      value: 123,
+    });
+  });
+  test('fail: integer', () => {
+    const data = 'invalid';
+    const result = parsePrimitive('test', data, 'integer');
+    expect(result).toEqual({
+      key: 'test',
+      value: NaN, // TODO: should show error?
+    });
+  });
+  test('success: float', () => {
+    const data = '123.123';
+    const result = parsePrimitive('test', data, 'float');
+    expect(result).toEqual({
+      key: 'test',
+      value: 123.123,
+    });
+  });
+  test('fail: float', () => {
+    const data = 'invalid';
+    const result = parsePrimitive('test', data, 'float');
+    expect(result).toEqual({
+      key: 'test',
+      value: NaN, // TODO: should show error?
+    });
+  });
+  test('success: multiple date formats', () => {
+    // multiple different date formats accepted
+    // TODO: times are checked in current timezone
+    const date1 = format(new Date('2023-09-19T18:00:00.000Z'), 'd/M/y h:m:s a');
+    const date2 = format(
+      new Date('2023-09-19T18:00:00.000Z'),
+      'yyyyMMdd_HHmmss',
+    );
+    const date3 = format(new Date('2023-09-19'), 'yyyyMMdd');
+    const result1 = parsePrimitive('test', date1, 'date');
+    // const result2 = parsePrimitive('test', date2, 'date');
+    // const result3 = parsePrimitive('test', date3, 'date');
+    const expectedDateTime = '2023-09-19T18:00:00.000Z';
+    const expectedDateOnly = '2023-09-19T00:00:00.000Z';
+
+    expect(result1).toEqual({
+      key: 'test',
+      value: expectedDateTime,
+    });
+    // TODO: fix these
+    // expect(result2).toEqual({
+    //   key: 'test',
+    //   value: expectedDateTime,
+    // });
+    // expect(result3).toEqual({
+    //   key: 'test',
+    //   value: expectedDateOnly,
+    // });
+  });
+});

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/pathDataParser.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/pathDataParser.test.ts
@@ -1,0 +1,92 @@
+import { IExtractionSpec } from '../../../../types';
+import { KeyData } from '../../../utils';
+import { extractPathData } from '../pathDataParser';
+
+jest.mock('../../../../utils/logger', () => {
+  return {
+    log: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+    },
+    logParsingException: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+const extractionSpec = {
+  fileNameExtractionSpec: {},
+  folderTreeExtractionSpec: {
+    '1': { name: 'part1' },
+    '2': { name: 'part2' },
+    '3': { name: 'part3' },
+    '4': { name: 'filename' },
+  },
+  vRunFolderTreeExtractionSpec: {
+    '1': { name: 'vPart1' },
+    '2': { name: 'filename' },
+  },
+  fileContentExtractionSpec: {},
+};
+
+describe('extractPathData', () => {
+  test('success: normal run', () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', '1', 'test_123_456.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456.txt',
+      fileBaseName: 'test_123_456',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/path/1/test_123_456',
+    };
+
+    const result = extractPathData(
+      keyData,
+      extractionSpec as any as IExtractionSpec,
+    );
+    expect(result).toEqual({
+      part1: 'test',
+      part2: 'path',
+      part3: '1',
+    });
+  });
+  test('success: virtual run', () => {
+    const keyData: KeyData = {
+      path: ['test', 'test_123_456.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456.txt',
+      fileBaseName: 'test_123_456',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/test_123_456',
+    };
+
+    const result = extractPathData(
+      keyData,
+      extractionSpec as any as IExtractionSpec,
+    );
+    expect(result).toEqual({
+      vPart1: 'test',
+    });
+  });
+  test('fail: wrong amount of directories', () => {
+    const keyData: KeyData = {
+      path: ['test', 'path', 'test_123_456.txt'],
+      rootFolder: 'test',
+      fileName: 'test_123_456.txt',
+      fileBaseName: 'test_123_456',
+      fileSuffix: 'txt',
+      keyWithoutSuffix: 'test/path/test_123_456',
+    };
+
+    const result = extractPathData(
+      keyData,
+      extractionSpec as any as IExtractionSpec,
+    );
+    expect(result).toEqual({});
+  });
+});

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
@@ -13,7 +13,7 @@ import {
 import { log, logParsingException } from '../../../utils/logger';
 import { parsePrimitive } from './parsePrimitives';
 
-const parseFileNameParts = (
+export const parseFileNameParts = (
   labels: IExtractionSpecLabels,
   fileBaseNameParts: Array<string>,
 ) =>
@@ -35,7 +35,7 @@ const parseFileNameParts = (
     return acc;
   }, {});
 
-const validateGenericFileNameStructureOrFail = (
+export const validateGenericFileNameStructureOrFail = (
   fileName: string,
   labels: IExtractionSpecLabels,
   fileBaseNameParts: Array<string>,

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/handleInspectionFileEvent.ts
@@ -102,7 +102,7 @@ export async function handleInspectionFileEvent(event: S3Event): Promise<void> {
   }
 }
 
-async function parseFileMetadata({
+export async function parseFileMetadata({
   keyData,
   file,
   spec,

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/parseFileMetadata.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/parseFileMetadata.ts
@@ -1,0 +1,39 @@
+import { IExtractionSpec, IFileResult, ParseValueResult } from '../../../types';
+import { KeyData } from '../../utils';
+import {
+  calculateHash,
+  extractFileContentData,
+  shouldParseContent,
+} from './contentDataParser';
+import { extractFileNameData } from './fileNameDataParser';
+import { extractPathData } from './pathDataParser';
+
+export async function parseFileMetadata({
+  keyData,
+  file,
+  spec,
+}: {
+  keyData: KeyData;
+  file: IFileResult;
+  spec: IExtractionSpec;
+}): Promise<{ metadata: ParseValueResult; hash: string }> {
+  const { fileBody } = file;
+  const fileNameData = extractFileNameData(
+    keyData,
+    spec.fileNameExtractionSpec,
+  );
+  const pathData = extractPathData(keyData, spec);
+  const fileContentData =
+    shouldParseContent(keyData.fileSuffix) && fileBody
+      ? extractFileContentData(spec, fileBody)
+      : {};
+  const hash = calculateHash(fileBody ?? '');
+  return {
+    metadata: {
+      ...pathData,
+      ...fileContentData,
+      ...fileNameData,
+    },
+    hash,
+  };
+}

--- a/backend/utils/logger.ts
+++ b/backend/utils/logger.ts
@@ -14,6 +14,7 @@ export const getCorrelationId = () => {
   if (correlationId) {
     return correlationId;
   }
+  return undefined;
 };
 
 function getLogger(tag: string) {

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,6 +10,8 @@ const jestConfig = {
    * `moduleDirectories`, @see {@link https://github.com/facebook/jest/issues/12889}
    */
   moduleDirectories: ['node_modules', __dirname],
+  collectCoverage: true,
+  coverageReporters: ['text'],
 };
 
 module.exports = createJestConfig(jestConfig);

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,6 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  collectCoverage: true,
+  coverageReporters: ['text'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testEnvironment: 'node',
-  roots: ['<rootDir>/test'],
+  roots: ['<rootDir>/backend'],
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',


### PR DESCRIPTION
Add unit tests for metadata parser and run them in the pipeline in a UnitTest step.

Some tests exist that have been explicitly skipped because they relate to bugs that need to be fixed.