### PR TITLE
RAITA-284: Fixes to datepicker 

### DIFF
--- a/frontend/components/daterange.tsx
+++ b/frontend/components/daterange.tsx
@@ -9,7 +9,7 @@ import { Range } from 'shared/types';
 import { DATE_FMT } from 'shared/constants';
 import { assoc } from 'rambda';
 import { useTranslation } from 'next-i18next';
-import { addDays, formatISO } from 'date-fns';
+import { add } from 'date-fns';
 
 export function DateRange(props: Props) {
   const { t } = useTranslation(['common']);
@@ -21,10 +21,11 @@ export function DateRange(props: Props) {
     end: range?.end,
   });
 
-  function getTomorrowDateString(dateString: string) {
-    const date = new Date(dateString);
-    const tomorrow = addDays(date, 1);
-    return formatISO(tomorrow, { representation: 'date' });
+  /**
+   * Assumes that param date is local time equivalent of UTC 00:00:00
+   */
+  function getEndOfDay(date: Date) {
+    return add(date, { hours: 23, minutes: 59, seconds: 59 });
   }
 
   //
@@ -64,6 +65,9 @@ export function DateRange(props: Props) {
             value={rangeValues[0]}
             className={clsx(css.input)}
             onChange={e => {
+              if (!e.target.value) {
+                return;
+              }
               const newStartDate = new Date(e.target.value);
               if (rangeValues[1] && newStartDate > new Date(rangeValues[1])) {
                 setState(assoc('end', undefined));
@@ -86,12 +90,15 @@ export function DateRange(props: Props) {
             {...{ disabled }}
             type={'date'}
             value={rangeValues[1]}
-            min={
-              rangeValues[0] ? getTomorrowDateString(rangeValues[0]) : undefined
-            }
+            min={rangeValues[0] ? rangeValues[0] : undefined}
             className={clsx(css.input)}
             onChange={e => {
-              setState(assoc('end', new Date(e.target.value)));
+              if (!e.target.value) {
+                return;
+              }
+              const date = new Date(e.target.value);
+              const endOfDay = getEndOfDay(date);
+              setState(assoc('end', endOfDay));
             }}
           />
 

--- a/frontend/components/daterange.tsx
+++ b/frontend/components/daterange.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { clsx } from 'clsx';
 import { format as formatDate } from 'date-fns/fp';
+import { add, isValid } from 'date-fns';
 
 import { Button } from 'components';
 
@@ -9,7 +10,6 @@ import { Range } from 'shared/types';
 import { DATE_FMT } from 'shared/constants';
 import { assoc } from 'rambda';
 import { useTranslation } from 'next-i18next';
-import { add } from 'date-fns';
 
 export function DateRange(props: Props) {
   const { t } = useTranslation(['common']);
@@ -65,10 +65,10 @@ export function DateRange(props: Props) {
             value={rangeValues[0]}
             className={clsx(css.input)}
             onChange={e => {
-              if (!e.target.value) {
+              const newStartDate = new Date(e.target.value);
+              if (!isValid(newStartDate)) {
                 return;
               }
-              const newStartDate = new Date(e.target.value);
               if (rangeValues[1] && newStartDate > new Date(rangeValues[1])) {
                 setState(assoc('end', undefined));
               }
@@ -93,11 +93,11 @@ export function DateRange(props: Props) {
             min={rangeValues[0] ? rangeValues[0] : undefined}
             className={clsx(css.input)}
             onChange={e => {
-              if (!e.target.value) {
+              const endDate = new Date(e.target.value);
+              if (!isValid(endDate)) {
                 return;
               }
-              const date = new Date(e.target.value);
-              const endOfDay = getEndOfDay(date);
+              const endOfDay = getEndOfDay(endDate);
               setState(assoc('end', endOfDay));
             }}
           />

--- a/frontend/pages/reports/index.tsx
+++ b/frontend/pages/reports/index.tsx
@@ -58,6 +58,7 @@ const initialState: ReportsState = {
     page: 1,
   },
   debug: false,
+  waitingToUpdateMutation: false,
 };
 
 //
@@ -165,7 +166,7 @@ const ReportsIndex: NextPage = () => {
 
   const doSearch = () => {
     setState(R.assocPath(['paging', 'page'], 1));
-    mutation.mutate(query);
+    setState(R.assocPath(['waitingToUpdateMutation'], true));
   };
 
   const resetSearch = () => {
@@ -204,6 +205,14 @@ const ReportsIndex: NextPage = () => {
     }
   }, [resultsData]);
 
+  // make sure mutation is updated only after query object is changed
+  useEffect(() => {
+    if (state.waitingToUpdateMutation) {
+      mutation.mutate(query);
+      setState(R.assoc('waitingToUpdateMutation', false));
+    }
+  }, [state.waitingToUpdateMutation]);
+
   const updateDateRange = (range: Range<Date>) => {
     setState(R.assocPath(['special', 'dateRange'], range));
     setState(R.assoc('resetFilters', false));
@@ -222,7 +231,7 @@ const ReportsIndex: NextPage = () => {
 
   const setPage = (n: number) => {
     setState(R.assocPath(['paging', 'page'], n));
-    mutation.mutate(query);
+    setState(R.assocPath(['waitingToUpdateMutation'], true));
   };
 
   /**
@@ -595,6 +604,7 @@ type ReportsState = {
     page: number;
   };
   debug?: boolean;
+  waitingToUpdateMutation: boolean;
 };
 
 type ReportFilters = Record<string, string>;


### PR DESCRIPTION
Some fixes to the time range start/end datepicker inputs:
 - The end date picker now uses 23:59 time instead of 00:00 so the whole day is covered
 - Allow selecting same start and end date to select only results from one day

Also fix two bugs not originally in the scope of the ticket:
- Fix a javascript crash when inputing invalid or empty values in the datepicker
- When changing results page, make sure page number is updated in the query before refetching