### PR TITLE
RAITA-329: first version of metadata parsing errors

### DIFF
--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/fileNameDataParser.ts
@@ -49,6 +49,7 @@ export const validateGenericFileNameStructureOrFail = (
   if (fileBaseNameParts.length !== expectedFileNamePartCount) {
     throw new RaitaParseError(
       `Unexpected number of file name segments in ${fileName}. Expected ${expectedFileNamePartCount}, received ${fileBaseNameParts.length}.`,
+      'WRONG_NUMBER_OF_FILE_NAME_SEGMENTS',
     );
   }
 };
@@ -77,10 +78,16 @@ export const extractFileNameData = (
   try {
     const { fileName, fileBaseName, fileSuffix } = keyData;
     if (!fileBaseName || !fileSuffix) {
-      throw new RaitaParseError(`Unexpected file name structure: ${fileName}`);
+      throw new RaitaParseError(
+        `Unexpected file name structure: ${fileName}`,
+        'WRONG_FILE_NAME_STRUCTURE',
+      );
     }
     if (!isKnownSuffix(fileSuffix)) {
-      throw new RaitaParseError(`Unexpected suffix in file name: ${fileName}`);
+      throw new RaitaParseError(
+        `Unexpected suffix in file name: ${fileName}`,
+        'WRONG_FILE_TYPE',
+      );
     }
     // File name segments are separated by underscore
     const fileBaseNameParts = fileBaseName.split('_');
@@ -98,6 +105,7 @@ export const extractFileNameData = (
     // Currently just log file name parsing errors.
     if (error instanceof RaitaParseError) {
       logParsingException.warn(
+        { errorType: error.errorType },
         `${error.message}. File name extraction skipped.`,
       );
       return {};

--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/pathDataParser.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/pathDataParser.ts
@@ -12,6 +12,7 @@ export const extractPathData = (keyData: KeyData, spec: IExtractionSpec) => {
   const folderParsingSpec = determineParsingSpec(keyData, spec);
   if (!folderParsingSpec) {
     logParsingException.warn(
+      { errorType: 'WRONG_FOLDER_PATH_LENGTH' },
       `Unexpected folder path length ${path.length} for path ${path}. Folder path analysis not carried out`,
     );
     return {};
@@ -32,11 +33,11 @@ export const extractPathData = (keyData: KeyData, spec: IExtractionSpec) => {
   }, {});
 };
 
- // Submission Report Excel files are located higher in the hierarchy than other files which always are at the lowest level,
-  // as quick and dirty solution expectedPathLength for these Excel files is hard coded to 5 which corresponds to their location.
-  // This is a rough implementation which can be replaced with more sofisticated one as the needs for
-  // path data parsing come more clear (is is enough to configure this based on file suffix or if more detailed configration is needed),
-  // more robust solution should be built on modifying the structure in extractionSpec parsing instructions. See Jira 242.
+// Submission Report Excel files are located higher in the hierarchy than other files which always are at the lowest level,
+// as quick and dirty solution expectedPathLength for these Excel files is hard coded to 5 which corresponds to their location.
+// This is a rough implementation which can be replaced with more sofisticated one as the needs for
+// path data parsing come more clear (is is enough to configure this based on file suffix or if more detailed configration is needed),
+// more robust solution should be built on modifying the structure in extractionSpec parsing instructions. See Jira 242.
 const determineParsingSpec = (keyData: KeyData, spec: IExtractionSpec) => {
   const { fileSuffix, fileBaseName, path } = keyData;
   switch (true) {

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -22,8 +22,12 @@ export class RaitaLambdaError extends Error {
 }
 
 export class RaitaParseError extends Error {
-  constructor(message: string) {
+  errorType: string = 'GENERIC_PARSING_ERROR';
+  constructor(message: string, errorType?: string) {
     super(message);
+    if (errorType) {
+      this.errorType = errorType;
+    }
   }
 }
 

--- a/lib/raita-data-process.ts
+++ b/lib/raita-data-process.ts
@@ -248,6 +248,7 @@ export class DataProcessStack extends NestedStack {
       }),
     );
     const allAlarms = [...receptionAlarms, ...inspectionAlarms];
+    // create composite alarm that triggers when any alarm for different error types trigger
     const compositeAlarm = new CompositeAlarm(
       this,
       'data-process-error-composite-alarm',
@@ -401,6 +402,8 @@ export class DataProcessStack extends NestedStack {
 
   /**
    * Add alarms for monitoring errors from logs
+   *
+   * Multiple alarms for different types if errors
    */
   private createInspectionHandlerAlarms(
     handler: NodejsFunction,


### PR DESCRIPTION
- Add cloudwatch alarms that trigger when data process lambdas log errors
- Add some more detail about the type of error in "errorType" field for logged messages
