### PR TITLE
RAITA-356 backup error message

### DIFF
--- a/frontend/components/loading-overlay.tsx
+++ b/frontend/components/loading-overlay.tsx
@@ -13,6 +13,19 @@ export function LoadingOverlay() {
       <p className="w-1/3 text-center text-white">
         {t('common:iam_problem_contact_info')}
       </p>
+      {/* Hardcoded error message if javascript isn't working. */}
+      <noscript>
+        <p>
+          Jos näet tämän virheviestin, syynä saattaa olla vanhojen
+          javascript-tiedostojen säilyminen välimuistissa sivustopäivityksen
+          jälkeen.
+        </p>
+        Mahdollisia korjauksia:
+        <ul>
+          <li>Tyhjennä selaimen välimuisti tältä sivulta: CTRL+F5</li>
+          <li>Kokeile toista selainta tai selaimen incognito-tilaa</li>
+        </ul>
+      </noscript>
     </div>
   );
 }

--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -5,7 +5,10 @@ const LocalStorageBackend = require('i18next-localstorage-backend').default;
 module.exports = {
   backend: {
     backendOptions: [
-      { expirationTime: 60 * 60 * 1000 },
+      {
+        expirationTime: 0, //60 * 60 * 1000,
+        // version: '', use a hash of translation files here if cache is enabled
+      },
       {
         /* loadPath: 'https:// somewhere else' */
       },


### PR DESCRIPTION
Add backup error message with noscript tags for when javascript fails.
Remove translation caching for now.