### PR TITLE
RAITA-573: Don't update parsed_at_datetime

### DIFF
--- a/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/postgresRepository.test.ts
+++ b/backend/lambdas/dataProcess/handleInspectionFileEvent/__tests__/postgresRepository.test.ts
@@ -1,14 +1,7 @@
+import { raportti } from '@prisma/client';
 import { FileMetadataEntry } from '../../../../types';
 import { checkExistingHash } from '../../../utils';
 import { jest } from '@jest/globals';
-
-// Mock the findReportByKey function
-jest.mock('../handleInspectionFileEvent', () => ({
-  findReportByKey: jest.fn(),
-}));
-
-// Get the mocked version of findReportByKey
-const findReportByKey = require('../handleInspectionFileEvent').findReportByKey;
 
 describe('PostgreRepository.upsertDocument', () => {
   const mockEntry = (overrides = {}): FileMetadataEntry => ({
@@ -31,43 +24,98 @@ describe('PostgreRepository.upsertDocument', () => {
     ...overrides,
   });
 
+  function mockFoundReport(overrides = {}): raportti {
+    return {
+      id: 1,
+      file_name: null,
+      file_type: null,
+      source_system: null,
+      zip_name: null,
+      campaign: null,
+      track_number: null,
+      track_part: null,
+      track_id: null,
+      km_start: null,
+      km_end: null,
+      system: null,
+      nonparsed_inspection_datetime: null,
+      report_category: null,
+      inspection_date: null,
+      size: null,
+      status: null,
+      error: null,
+      chunks_to_process: null,
+      events: null,
+      parsed_at_datetime: null,
+      key: null,
+      inspection_datetime: null,
+      parser_version: null,
+      zip_reception__year: null,
+      zip_reception__date: null,
+      year: null,
+      created: null,
+      modified: null,
+      metadata_changed_at_datetime: null,
+      extra_information: null,
+      metadata_status: null,
+      maintenance_area: null,
+      is_empty: null,
+      length: null,
+      tilirataosanumero: null,
+      report_type: null,
+      temperature: null,
+      measurement_start_location: null,
+      measurement_end_location: null,
+      measurement_direction: null,
+      maintenance_level: null,
+      hash: null,
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should return true if key is not found', async () => {
-    findReportByKey.mockResolvedValue(null);
+    const foundReport = null;
     const entry = mockEntry();
-    const result = await checkExistingHash(entry);
+    const result = await checkExistingHash(entry, foundReport);
     expect(result).toBe(true);
   });
 
   it('should return true if skip_hash_check is true and hash matches', async () => {
-    findReportByKey.mockResolvedValue({ hash: 'testHash' });
+    const foundReport = mockFoundReport({ hash: 'testHash' });
     const entry = mockEntry({ options: { skip_hash_check: true } });
-    const result = await checkExistingHash(entry);
+    const result = await checkExistingHash(entry, foundReport);
     expect(result).toBe(true);
   });
 
   it('should return true if found hash does not match entry hash', async () => {
-    findReportByKey.mockResolvedValue({ hash: 'differentHash' });
+    const foundReport = mockFoundReport({
+      hash: 'different-hash',
+      parser_version: '1.0.0',
+    });
     const entry = mockEntry();
-    const result = await checkExistingHash(entry);
+    const result = await checkExistingHash(entry, foundReport);
     expect(result).toBe(true);
   });
 
   it('should return true if require_newer_parser_version is true and version is newer or equal', async () => {
-    findReportByKey.mockResolvedValue({ parser_version: '1.0.0' });
+    const foundReport = mockFoundReport({
+      hash: 'testHash',
+      parser_version: '1.0.0',
+    });
     const entry = mockEntry({
       options: { require_newer_parser_version: true },
       metadata: { parser_version: '1.0.0' },
     });
-    const result = await checkExistingHash(entry);
+    const result = await checkExistingHash(entry, foundReport);
     expect(result).toBe(true);
   });
 
   it('should return false if require_newer_parser_version is true and version is older', async () => {
-    findReportByKey.mockResolvedValue({
+    const foundReport = mockFoundReport({
       hash: 'testHash',
       parser_version: '2.0.0',
     });
@@ -76,14 +124,17 @@ describe('PostgreRepository.upsertDocument', () => {
       metadata: { parser_version: '1.0.0' },
     });
 
-    const result = await checkExistingHash(entry);
+    const result = await checkExistingHash(entry, foundReport);
     expect(result).toBe(false);
   });
 
   it('should return false if none of the conditions are met', async () => {
-    findReportByKey.mockResolvedValue({ hash: 'testHash' });
+    const foundReport = mockFoundReport({
+      hash: 'testHash',
+      parser_version: '0.1.0',
+    });
     const entry = mockEntry();
-    const result = await checkExistingHash(entry);
+    const result = await checkExistingHash(entry, foundReport);
     expect(result).toBe(false);
   });
 });

--- a/backend/lambdas/utils.ts
+++ b/backend/lambdas/utils.ts
@@ -210,6 +210,12 @@ export async function checkExistingHash(
       const requireNewerParserVersion =
         entry.options.require_newer_parser_version;
 
+      // updating existing file: don't update parsed_at_datetime
+      const oldParsedAt = foundReport.parsed_at_datetime
+        ? foundReport.parsed_at_datetime.toISOString()
+        : null;
+      entry.metadata.parsed_at_datetime = oldParsedAt;
+
       if (skipHashCheck && foundReport.hash === entry.hash) return true;
 
       if (foundReport.hash !== entry.hash) return true;


### PR DESCRIPTION
If report is found, don't update parsed_at_datetime matadata. Instead use the one within the found report.