### PR TITLE
Fixes to zip downloading-merge conflict

### DIFF
--- a/frontend/components/header/index.tsx
+++ b/frontend/components/header/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useContext } from 'react';
+import { PropsWithChildren, useContext, useEffect } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -9,7 +9,7 @@ import { PageDescription } from 'shared/pageRoutes';
 import LatestInspectionDate from 'components/latest_inspection_date';
 import { assetURL } from 'shared/config';
 import { zipContext } from 'shared/zipContext';
-import { ZipDownload } from 'components/zip-download-graphql';
+import * as R from 'rambda';
 import { PollingHandler } from 'components/pollingHandler';
 type Props = {
   pages: PageDescription[];
@@ -22,7 +22,13 @@ const Header = ({ pages, children }: PropsWithChildren<Props>) => {
   const router = useRouter();
   const pathSplit = router.pathname.split('/');
   const pageTitleKey = `page_labels${pathSplit.join('.')}`;
-  const zipState = useContext(zipContext);
+  const { state, setState } = useContext(zipContext);
+  useEffect(() => {
+    const storedZipUrl = localStorage.getItem('zipUrl');
+    if (typeof storedZipUrl === 'string') {
+      setState(R.assoc('zipUrl', storedZipUrl));
+    }
+  }, []);
   return (
     <>
       <header className="bg-primary text-white h-16">
@@ -52,8 +58,8 @@ const Header = ({ pages, children }: PropsWithChildren<Props>) => {
             <div className="flex flex-row justify-end">
               <LatestInspectionDate className="my-auto mr-4" />
             </div>
-            {(zipState.state.zipUrl ||
-              zipState.state.isLoading ||
+            {(state.isLoading ||
+              state.zipUrl ||
               localStorage.getItem('zipUrl') ||
               localStorage.getItem('pollingFileKey')) && (
               <div className="ml-2 flex justify-end">

--- a/frontend/components/pollingHandler.tsx
+++ b/frontend/components/pollingHandler.tsx
@@ -14,10 +14,7 @@ export const PollingHandler = ({
   buttonType?: 'primary' | 'secondary' | 'tertiary';
 }) => {
   const { state, setState } = useContext(zipContext);
-  const { zipUrl, error, isLoading } = state;
-
-  const maxSize = 5 * 1000 * 1000 * 1000;
-  const bigSize = 1 * 1000 * 1000 * 1000;
+  const { error, isLoading } = state;
 
   const { t } = useTranslation(['common']);
   /* useEffect(() => {
@@ -59,6 +56,7 @@ export const PollingHandler = ({
           setState(initialState);
           setState(R.assoc('zipUrl', data.progressData.url));
           localStorage.setItem('zipUrl', data.progressData.url);
+          localStorage.removeItem('pollingFileKey');
         } else if (data?.progressData?.status === ProgressStatus.FAILED) {
           setState(initialState);
           setState(R.assoc('error', `${t('common:zip_error')}`));

--- a/frontend/components/zip-download-graphql.tsx
+++ b/frontend/components/zip-download-graphql.tsx
@@ -21,15 +21,15 @@ export function ZipDownload(props: Props) {
   const { state, setState } = useContext(zipContext);
   const { error, isLoading } = state;
 
-  const maxSize = 5 * 1000 * 1000 * 1000;
-  const bigSize = 1 * 1000 + 1000 + 1000;
-  const maxCount = 4000;
-
   const { t } = useTranslation(['common']);
 
   const [triggerKeyQuery, keyQuery] = useLazyQuery(SEARCH_RAPORTTI_KEYS_ONLY);
-  const isOverMaxSize = resultTotalSize ? resultTotalSize > maxSize : true;
-  const tooManyResults = aggregationSize ? aggregationSize > maxCount : true;
+  const isOverMaxSize = resultTotalSize
+    ? resultTotalSize > cfg.maxFileSizeForZip
+    : true;
+  const tooManyResults = aggregationSize
+    ? aggregationSize > cfg.maxFileCountForZip
+    : true;
 
   const triggerKeyFetching = () => {
     if (usedQueryVariables) {

--- a/frontend/components/zip-download-graphql.tsx
+++ b/frontend/components/zip-download-graphql.tsx
@@ -17,16 +17,19 @@ import { zipContext } from 'shared/zipContext';
 // Copied from zip-download.tsx
 // TODO: rename when removing opensearch
 export function ZipDownload(props: Props) {
-  const { usedQueryVariables, resultTotalSize } = props;
+  const { usedQueryVariables, resultTotalSize, aggregationSize } = props;
   const { state, setState } = useContext(zipContext);
   const { error, isLoading } = state;
 
-  const maxSize = 15 * 1000 * 1000 * 1000;
+  const maxSize = 5 * 1000 * 1000 * 1000;
   const bigSize = 1 * 1000 + 1000 + 1000;
+  const maxCount = 4000;
 
   const { t } = useTranslation(['common']);
 
   const [triggerKeyQuery, keyQuery] = useLazyQuery(SEARCH_RAPORTTI_KEYS_ONLY);
+  const isOverMaxSize = resultTotalSize ? resultTotalSize > maxSize : true;
+  const tooManyResults = aggregationSize ? aggregationSize > maxCount : true;
 
   const triggerKeyFetching = () => {
     if (usedQueryVariables) {
@@ -71,14 +74,15 @@ export function ZipDownload(props: Props) {
   }, [state]);
 
   return (
-    <div>
+    <div className="flex items-end">
       {!error && (
-        <div className="flex gap-2 mb-1">
+        <div className="flex gap-2 mb-1 h-auto">
           {isLoading ? (
             <Spinner size={4} bottomMargin={0} />
           ) : (
             <Button
               size="sm"
+              disabled={isOverMaxSize || tooManyResults}
               label={`${t('common:compress_all')} ${sizeformatter(
                 resultTotalSize ? resultTotalSize : undefined,
               )}`}

--- a/frontend/pages/graphql_reports/index.tsx
+++ b/frontend/pages/graphql_reports/index.tsx
@@ -54,9 +54,6 @@ const initialState: ReportsState = {
   extraRaporttiQueryVariables: {},
 };
 
-const maxFileSizeForZip = 5 * 1000 * 1000 * 1000;
-const maxFileCountForZip = 4000;
-
 /**
  * Fields that should not be shown in extra fields dropdown
  */
@@ -438,12 +435,12 @@ const ReportsIndex: RaitaNextPage = () => {
                       ) : null}
 
                       <div className="ml-2">
-                        {resultsData.total_size > maxFileSizeForZip ? (
+                        {resultsData.total_size > cfg.maxFileSizeForZip ? (
                           <p className="text-base">
                             {t('common:file_size_limit')}
                           </p>
                         ) : null}
-                        {resultsData.count > maxFileCountForZip ? (
+                        {resultsData.count > cfg.maxFileCountForZip ? (
                           <p className="text-base">
                             {t('common:file_count_limit')}
                           </p>
@@ -452,16 +449,6 @@ const ReportsIndex: RaitaNextPage = () => {
                     </div>
                   )}
                 </div>
-              ) : (
-                <>
-                  <div className="flex items-end">
-                    <div className="mt-1">{t('common:no_results')}</div>
-                    {localStorage.getItem('zipUrl') ||
-                    zipState.state.isLoading ? (
-                      <PollingHandler />
-                    ) : null}
-                  </div>
-                </>
               )}
 
               <div>

--- a/frontend/pages/graphql_reports/index.tsx
+++ b/frontend/pages/graphql_reports/index.tsx
@@ -44,9 +44,7 @@ import {
 } from 'components/filters-graphql/selector';
 import { getInputVariablesFromEntries } from 'components/filters-graphql/utils';
 import { zipContext } from 'shared/zipContext';
-import { PollingHandler } from 'components/pollingHandler';
-
-//
+import { initialState as zipInitialState } from 'shared/zipContext';
 
 const initialState: ReportsState = {
   resetFilters: false,
@@ -55,6 +53,9 @@ const initialState: ReportsState = {
   queryVariables: { page: 1, page_size: cfg.paging.pageSize, raportti: {} },
   extraRaporttiQueryVariables: {},
 };
+
+const maxFileSizeForZip = 5 * 1000 * 1000 * 1000;
+const maxFileCountForZip = 4000;
 
 /**
  * Fields that should not be shown in extra fields dropdown
@@ -99,6 +100,8 @@ const ReportsIndex: RaitaNextPage = () => {
   const doSearch = () => {
     setState(R.assocPath(['queryVariables', 'page'], 1));
     setState(R.assocPath(['waitingToUpdateSearchQuery'], true));
+    localStorage.removeItem('zipUrl');
+    zipState.setState(zipInitialState);
     triggerInitialSearch({
       variables: getQueryVariables(state),
     });
@@ -411,27 +414,43 @@ const ReportsIndex: RaitaNextPage = () => {
 
           <section className="col-span-2">
             <header className="text-3xl border-b-2 border-gray-500 mb-4 pb-2">
-              {searchQuery.data &&
-              resultsData?.total_size &&
-              resultsData?.total_size > 0 ? (
+              {!searchQuery.data && (
+                <div className="flex items-end">
+                  <div className="mt-1"> {t('common:no_results')}</div>
+                </div>
+              )}
+
+              {searchQuery.data && (
                 <div className="flex items-end">
                   <div className="mt-1">
                     {t('search_result_count', {
                       count: resultsData?.count,
                     })}
                   </div>
+                  {resultsData?.total_size && resultsData?.total_size > 0 && (
+                    <div className="ml-2 flex">
+                      {!localStorage.getItem('zipUrl') ? (
+                        <ZipDownload
+                          aggregationSize={resultsData?.count}
+                          usedQueryVariables={getQueryVariables(state)}
+                          resultTotalSize={resultsData?.total_size}
+                        />
+                      ) : null}
 
-                  <div className="ml-2 flex">
-                    {!localStorage.getItem('zipUrl') ? (
-                      <ZipDownload
-                        aggregationSize={resultsData?.count}
-                        usedQueryVariables={getQueryVariables(state)}
-                        resultTotalSize={resultsData?.total_size}
-                      />
-                    ) : (
-                      <PollingHandler />
-                    )}
-                  </div>
+                      <div className="ml-2">
+                        {resultsData.total_size > maxFileSizeForZip ? (
+                          <p className="text-base">
+                            {t('common:file_size_limit')}
+                          </p>
+                        ) : null}
+                        {resultsData.count > maxFileCountForZip ? (
+                          <p className="text-base">
+                            {t('common:file_count_limit')}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <>

--- a/frontend/public/locales/fi/common.json
+++ b/frontend/public/locales/fi/common.json
@@ -92,5 +92,7 @@
   "search_csv": "Hae mittausrivien määrä",
   "generate_csv": "Generoi CSV-tiedosto",
   "page_labels.graphql_reports": "Raportit",
-  "to_page": "Siirry sivulle"
+  "to_page": "Siirry sivulle",
+  "file_count_limit": "Tiedostomäärän oltava alle 4000",
+  "file_size_limit": "Tiedoston koko oltava alle 5 GB"
 }

--- a/frontend/shared/config.ts
+++ b/frontend/shared/config.ts
@@ -22,6 +22,8 @@ export const paging = {
   maxZipPageSize: 5000, // max size to use for zipping. If larger sizes are required, need to rework zip download so that list of keys is not fetched in frontend
 } as const;
 
+export const maxFileSizeForZip = 5 * 1000 * 1000 * 1000;
+export const maxFileCountForZip = 4000;
 // index of zip file name in file key
 export const zipFileNameIndex = 5;
 


### PR DESCRIPTION
Download buttons now only in header row.

New search triggers former zip package to vanish.

Over 5GB and 4000kpl files not possible to download.