### PR TITLE
fix/RAITA-668-graphql-uri-fix

### DIFF
--- a/frontend/shared/graphql/client.ts
+++ b/frontend/shared/graphql/client.ts
@@ -1,6 +1,7 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { baseURL } from 'shared/config';
 
 export const apolloClient = new ApolloClient({
-  uri: '/api/v2/graphql',
+  uri: `${baseURL}/v2/graphql`,
   cache: new InMemoryCache(),
 });


### PR DESCRIPTION
apolloClient configured to /premain/api instead of /api if in premain environment.