### PR TITLE
Feat/RAITA-512 csv search with rataosoite

### DIFF
--- a/backend/apollo/resolvers/mittaus.ts
+++ b/backend/apollo/resolvers/mittaus.ts
@@ -61,6 +61,18 @@ export const mittausResolvers: Resolvers = {
             // TODO: search with mittaus specific fields
             in: raporttiRows.map(raportti => raportti.id),
           },
+
+          ...((mittaus.rata_kilometri?.start !== undefined ||
+            mittaus.rata_kilometri?.end !== undefined) && {
+            rata_kilometri: {
+              ...(mittaus.rata_kilometri?.start !== undefined && {
+                gte: mittaus.rata_kilometri.start,
+              }),
+              ...(mittaus.rata_kilometri?.end !== undefined && {
+                lte: mittaus.rata_kilometri.end,
+              }),
+            },
+          }),
         },
       });
       return {

--- a/backend/apollo/schemas/mittaus.graphql
+++ b/backend/apollo/schemas/mittaus.graphql
@@ -35,7 +35,7 @@ type MittausGenerateResponse {
 input MittausInput {
   ## Mittaus common fields
   # track: String
-  rata_kilometri: Int ## TODO: is it useful to search with these at all? they are not consistent between files
+  rata_kilometri: IntIntervalInput ## TODO: is it useful to search with these at all? they are not consistent between files
   rata_metrit: Float
   ## TODO: system specific fields
 }

--- a/frontend/pages/csv/index.tsx
+++ b/frontend/pages/csv/index.tsx
@@ -370,7 +370,30 @@ const CsvIndex: RaitaNextPage = () => {
             {showRaporttiQueryError && <p>{t('common:error_loading')}</p>}
 
             {showRaporttiResults && (
-              <>
+              /*Keijo tänne ratakilometrit */ <>
+                <section className={clsx(css.subSection)}>
+                  <header>Mittausarvojen tiedot</header>
+                  <FilterSelector
+                    filters={[]}
+                    onChange={entries => {
+                      const inputVariables =
+                        getInputVariablesFromEntries(entries);
+                      // replace the whole
+                      setState(
+                        R.assocPath(
+                          ['extraRaporttiQueryVariables'],
+                          inputVariables,
+                        ),
+                      );
+                      setMittausCountIsFresh(false);
+                    }}
+                    fields={{
+                      km_start: { type: 'IntIntervalInput' }, // väärä type
+                      km_end: { type: 'IntIntervalInput' },
+                    }}
+                    resetFilterSelector={state.resetFilters}
+                  />
+                </section>
                 <section className={clsx(css.subSection)}>
                   <MultiChoice
                     label={t('common:choose_columns')}

--- a/frontend/pages/csv/index.tsx
+++ b/frontend/pages/csv/index.tsx
@@ -83,6 +83,10 @@ const getQueryVariables = (state: CsvState) => {
       ...state.queryVariables.raportti,
       ...state.extraRaporttiQueryVariables,
     },
+    mittaus: {
+      ...state.queryVariables.mittaus,
+      rata_kilometri: state.queryVariables.mittaus.rata_kilometri ?? null,
+    },
   };
 };
 
@@ -223,7 +227,7 @@ const CsvIndex: RaitaNextPage = () => {
         value: columnName,
       })),
     )
-    .concat({ key: 'ajonopeus', value: 'ajonopeus' });
+    .concat([{ key: 'ajonopeus', value: 'ajonopeus' }]);
 
   return (
     <div className={clsx(css.root, isLoading && css.isLoading)}>
@@ -370,26 +374,25 @@ const CsvIndex: RaitaNextPage = () => {
             {showRaporttiQueryError && <p>{t('common:error_loading')}</p>}
 
             {showRaporttiResults && (
-              /*Keijo tänne ratakilometrit */ <>
+              <>
                 <section className={clsx(css.subSection)}>
-                  <header>Mittausarvojen tiedot</header>
+                  <header>{t('common:csv_filter_header')}</header>
                   <FilterSelector
                     filters={[]}
                     onChange={entries => {
                       const inputVariables =
                         getInputVariablesFromEntries(entries);
-                      // replace the whole
+
                       setState(
                         R.assocPath(
-                          ['extraRaporttiQueryVariables'],
+                          ['queryVariables', 'mittaus'],
                           inputVariables,
                         ),
                       );
                       setMittausCountIsFresh(false);
                     }}
                     fields={{
-                      km_start: { type: 'IntIntervalInput' }, // väärä type
-                      km_end: { type: 'IntIntervalInput' },
+                      rata_kilometri: { type: 'IntIntervalInput' },
                     }}
                     resetFilterSelector={state.resetFilters}
                   />

--- a/frontend/public/locales/fi/common.json
+++ b/frontend/public/locales/fi/common.json
@@ -97,5 +97,5 @@
   "file_size_limit": "Tiedoston koko oltava alle 5 GB",
   "stale_mittaus_count": "Huom: hakuehtoja on muutettu, näytetty mittausten määrä ei välttämättä enää vastaa valittuja hakuehtoja. Tee uusi haku päivittääksesi mittausten määrä.",
   "error_size_limit": "Virhe: liian suuri datamäärä. Rajaa hakuehtoja tarkemmaksi",
-  "csv_filter_header": "Mittausarvojen suodin"
+  "csv_filter_header": "Mittausarvojen suodatin"
 }

--- a/frontend/public/locales/fi/common.json
+++ b/frontend/public/locales/fi/common.json
@@ -96,5 +96,6 @@
   "file_count_limit": "Tiedostomäärän oltava alle 4000",
   "file_size_limit": "Tiedoston koko oltava alle 5 GB",
   "stale_mittaus_count": "Huom: hakuehtoja on muutettu, näytetty mittausten määrä ei välttämättä enää vastaa valittuja hakuehtoja. Tee uusi haku päivittääksesi mittausten määrä.",
-  "error_size_limit": "Virhe: liian suuri datamäärä. Rajaa hakuehtoja tarkemmaksi"
+  "error_size_limit": "Virhe: liian suuri datamäärä. Rajaa hakuehtoja tarkemmaksi",
+  "csv_filter_header": "Mittausarvojen suodin"
 }

--- a/frontend/public/locales/fi/metadata.json
+++ b/frontend/public/locales/fi/metadata.json
@@ -31,6 +31,7 @@
   "label_extra_information": "Lisätietoja",
   "label_metadata_changed_at_datetime": "Metatietojen päivitysaika",
   "label_is_empty": "Tyhjä",
+  "label_rata_kilometri": "Ratakilometri",
   "AMS": "Kulkudynamiikan mittaus",
   "TG": "Raiteiden ja vaihteiden geometrian mittaus",
   "TGMS": "Raiteiden ja vaihteiden geometrian mittaus",


### PR DESCRIPTION
csv can be filtered by rataosoite. Rataosoite can be set as "less-than-or-equal" or "greater-than-or-equal". With two parameters the values will be selected in between, but not the other way around. This is ok: 10>x>20. Values from parameters like this are not working: x > 20 / 40 <x